### PR TITLE
Fix bugs in lb_vpx_vip and lb_vpx_service

### DIFF
--- a/softlayer/resource_softlayer_lb_vpx_service_test.go
+++ b/softlayer/resource_softlayer_lb_vpx_service_test.go
@@ -15,11 +15,17 @@ func TestAccSoftLayerLbVpxService_Basic(t *testing.T) {
 				Config: testAccCheckSoftLayerLbVpxServiceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"softlayer_lb_vpx.testacc_service", "name", "test_load_balancer_service"),
+						"softlayer_lb_vpx_service.testacc_service1", "name", "test_load_balancer_service1"),
 					resource.TestCheckResourceAttr(
-						"softlayer_lb_vpx.testacc_service", "destination_port", "89"),
+						"softlayer_lb_vpx_service.testacc_service1", "destination_port", "89"),
 					resource.TestCheckResourceAttr(
-						"softlayer_lb_vpx.testacc_service", "weight", "55"),
+						"softlayer_lb_vpx_service.testacc_service1", "weight", "55"),
+					resource.TestCheckResourceAttr(
+						"softlayer_lb_vpx_service.testacc_service2", "name", "test_load_balancer_service2"),
+					resource.TestCheckResourceAttr(
+						"softlayer_lb_vpx_service.testacc_service2", "destination_port", "89"),
+					resource.TestCheckResourceAttr(
+						"softlayer_lb_vpx_service.testacc_service2", "weight", "55"),
 				),
 			},
 		},
@@ -27,40 +33,37 @@ func TestAccSoftLayerLbVpxService_Basic(t *testing.T) {
 }
 
 var testAccCheckSoftLayerLbVpxServiceConfig_basic = `
-resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
-    name = "terraform-test"
-    domain = "bar.example.com"
+
+resource "softlayer_virtual_guest" "vm1" {
+    name = "vm1"
+    domain = "example.com"
     image = "DEBIAN_7_64"
-    region = "ams01"
+    datacenter = "wdc01"
     public_network_speed = 10
     hourly_billing = true
     private_network_only = false
     cpu = 1
     ram = 1024
-    disks = [25, 10, 20]
-    user_data = "{\"value\":\"newvalue\"}"
-    dedicated_acct_host_only = true
+    disks = [25]
     local_disk = false
 }
 
-resource "softlayer_virtual_guest" "terraform-acceptance-test-2" {
-    name = "terraform-test"
-    domain = "bar.example.com"
+resource "softlayer_virtual_guest" "vm2" {
+    name = "vm2"
+    domain = "example.com"
     image = "DEBIAN_7_64"
-    region = "ams01"
+    datacenter = "wdc01"
     public_network_speed = 10
     hourly_billing = true
-	private_network_only = false
+    private_network_only = false
     cpu = 1
     ram = 1024
-    disks = [25, 10, 20]
-    user_data = "{\"value\":\"newvalue\"}"
-    dedicated_acct_host_only = true
+    disks = [25]
     local_disk = false
 }
 
-resource "softlayer_lb_vpx" "testacc_foobar_vpx" {
-    datacenter = "DALLAS06"
+resource "softlayer_lb_vpx" "testacc_vpx" {
+    datacenter = "wdc01"
     speed = 10
     version = "10.1"
     plan = "Standard"
@@ -69,17 +72,27 @@ resource "softlayer_lb_vpx" "testacc_foobar_vpx" {
 
 resource "softlayer_lb_vpx_vip" "testacc_vip" {
     name = "test_load_balancer_vip"
-    nad_controller_id = "${softlayer_lb_vpx.testacc_foobar_vpx.id}"
+    nad_controller_id = "${softlayer_lb_vpx.testacc_vpx.id}"
     load_balancing_method = "lc"
-    source_port = 81
+    source_port = 80
     type = "HTTP"
-    virtual_ip_address = "${softlayer_virtual_guest.terraform-acceptance-test-1.ipv4_address}"
+    virtual_ip_address = "${softlayer_lb_vpx.testacc_vpx.vip_pool[0]}"
 }
 
-resource "softlayer_lb_vpx_service" "testacc_service" {
-  name = "test_load_balancer_service"
+resource "softlayer_lb_vpx_service" "testacc_service1" {
+  name = "test_load_balancer_service1"
   vip_id = "${softlayer_lb_vpx_vip.testacc_vip.id}"
-  destination_ip_address = "${softlayer_virtual_guest.terraform-acceptance-test-2.ipv4_address}"
+  destination_ip_address = "${softlayer_virtual_guest.vm1.ipv4_address}"
+  destination_port = 89
+  weight = 55
+  connection_limit = 5000
+  health_check = "HTTP"
+}
+
+resource "softlayer_lb_vpx_service" "testacc_service2" {
+  name = "test_load_balancer_service2"
+  vip_id = "${softlayer_lb_vpx_vip.testacc_vip.id}"
+  destination_ip_address = "${softlayer_virtual_guest.vm2.ipv4_address}"
   destination_port = 89
   weight = 55
   connection_limit = 5000

--- a/softlayer/resource_softlayer_lb_vpx_vip_test.go
+++ b/softlayer/resource_softlayer_lb_vpx_vip_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/softlayer/softlayer-go/filter"
-	"github.com/softlayer/softlayer-go/services"
+	"github.com/softlayer/softlayer-go/helpers/network"
 	"github.com/softlayer/softlayer-go/session"
 )
 
@@ -37,7 +36,7 @@ func TestAccSoftLayerLbVpxVip_Basic(t *testing.T) {
 }
 
 func testAccCheckSoftLayerLbVpxVipDestroy(s *terraform.State) error {
-	service := services.GetNetworkApplicationDeliveryControllerService(testAccProvider.Meta().(*session.Session))
+	sess := testAccProvider.Meta().(*session.Session)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "softlayer_lb_vpx_vip" {
@@ -47,12 +46,9 @@ func testAccCheckSoftLayerLbVpxVipDestroy(s *terraform.State) error {
 		nadcId, _ := strconv.Atoi(rs.Primary.Attributes["nad_controller_id"])
 		vipName, _ := rs.Primary.Attributes["name"]
 
-		vips, _ := service.
-			Id(nadcId).
-			Filter(filter.Path("name").Eq(vipName).Build()).
-			GetLoadBalancers()
+		vip, _ := network.GetNadcLbVipByName(sess, nadcId, vipName)
 
-		if len(vips) > 0 {
+		if vip != nil {
 			return fmt.Errorf("Netscaler VPX VIP still exists")
 		}
 	}

--- a/vendor/github.com/softlayer/softlayer-go/helpers/network/network.go
+++ b/vendor/github.com/softlayer/softlayer-go/helpers/network/network.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/softlayer/softlayer-go/datatypes"
-	"github.com/softlayer/softlayer-go/filter"
 	"github.com/softlayer/softlayer-go/services"
 	"github.com/softlayer/softlayer-go/session"
 )
@@ -33,23 +32,25 @@ func GetNadcLbVipByName(sess *session.Session, nadcId int, vipName string, mask 
 	service := services.GetNetworkApplicationDeliveryControllerService(sess)
 
 	service = service.
-		Id(nadcId).
-		Filter(filter.Path("name").Eq(vipName).Build())
+		Id(nadcId)
 
 	if len(mask) > 0 {
 		service = service.Mask(mask[0])
 	}
 
 	vips, err := service.GetLoadBalancers()
+
 	if err != nil {
 		return nil, fmt.Errorf("Error getting NADC load balancers: %s", err)
 	}
 
-	if len(vips) == 0 {
-		return nil, fmt.Errorf("Could not find any VIPs for NADC %d matching name %s", nadcId, vipName)
+	for _, vip := range vips {
+		if *vip.Name == vipName {
+			return &vip, nil
+		}
 	}
 
-	return &vips[0], nil
+	return nil, fmt.Errorf("Could not find any VIPs for NADC %d matching name %s", nadcId, vipName)
 }
 
 // GetNadcLbVipServiceByName Get a load balancer service by name attached to a load balancer

--- a/vendor/github.com/softlayer/softlayer-go/helpers/product/product.go
+++ b/vendor/github.com/softlayer/softlayer-go/helpers/product/product.go
@@ -39,6 +39,9 @@ const NICSpeedCategoryCode = "port_speed"
 // DedicatedLoadBalancerCategoryCode Category code for Dedicated Load Balancer
 const DedicatedLoadBalancerCategoryCode = "dedicated_load_balancer"
 
+// ProxyLoadBalancerCategoryCode Category code for Shared local load balancer (proxy load balancer)
+const ProxyLoadBalancerCategoryCode = "proxy_load_balancer"
+
 // GetPackageByType Get the Product_Package which matches the specified
 // package type
 func GetPackageByType(

--- a/vendor/github.com/softlayer/softlayer-go/meta/loadmeta.go
+++ b/vendor/github.com/softlayer/softlayer-go/meta/loadmeta.go
@@ -390,15 +390,16 @@ func fixDatatype(t *Type, meta map[string]Type) {
 
 // Special case for fixing some broken return types in the metadata
 func fixReturnType(service *Type) {
-	brokenServices := map[string]struct{}{
-		"SoftLayer_Network_Application_Delivery_Controller_LoadBalancer_Service":       {},
-		"SoftLayer_Network_Application_Delivery_Controller_LoadBalancer_VirtualServer": {},
+	brokenServices := map[string]string{
+		"SoftLayer_Network_Application_Delivery_Controller_LoadBalancer_Service":       "deleteObject",
+		"SoftLayer_Network_Application_Delivery_Controller_LoadBalancer_VirtualServer": "deleteObject",
+		"SoftLayer_Network_Application_Delivery_Controller":                            "deleteLiveLoadBalancerService",
 	}
 
-	if _, ok := brokenServices[service.Name]; ok {
-		method := service.Methods["deleteObject"]
+	if methodName, ok := brokenServices[service.Name]; ok {
+		method := service.Methods[methodName]
 		method.Type = "void"
-		service.Methods["deleteObject"] = method
+		service.Methods[methodName] = method
 	}
 }
 

--- a/vendor/github.com/softlayer/softlayer-go/services/network.go
+++ b/vendor/github.com/softlayer/softlayer-go/services/network.go
@@ -252,7 +252,8 @@ func (r Network_Application_Delivery_Controller) DeleteLiveLoadBalancer(loadBala
 }
 
 // Remove an entire load balancer service, including all virtual IP addresses, from and application delivery controller based load balancer. The ''name'' property the and ''name'' property within the ''vip'' property of the service parameter must be provided. Changes are reflected immediately in the application delivery controller.
-func (r Network_Application_Delivery_Controller) DeleteLiveLoadBalancerService(service *datatypes.Network_LoadBalancer_Service) (resp bool, err error) {
+func (r Network_Application_Delivery_Controller) DeleteLiveLoadBalancerService(service *datatypes.Network_LoadBalancer_Service) (err error) {
+	var resp datatypes.Void
 	params := []interface{}{
 		service,
 	}

--- a/vendor/github.com/softlayer/softlayer-go/session/rest.go
+++ b/vendor/github.com/softlayer/softlayer-go/session/rest.go
@@ -178,6 +178,9 @@ func makeHTTPRequest(session *Session, path string, requestType string, requestB
 		return nil, resp.StatusCode, err
 	}
 
+	if session.Debug {
+		log.Println("[DEBUG] Response: ", string(responseBody))
+	}
 	return responseBody, resp.StatusCode, nil
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -5,80 +5,80 @@
 		{
 			"checksumSHA1": "KeNIYJQUdE6o196SaYuLMmjEPZM=",
 			"path": "github.com/softlayer/softlayer-go/config",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
 			"checksumSHA1": "mjpt7bp+Tx5LtpwP+5kx0R/Q1vs=",
 			"path": "github.com/softlayer/softlayer-go/datatypes",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
 			"checksumSHA1": "nmqOPqyvDmGdvAntqvg/e0VfdbY=",
 			"path": "github.com/softlayer/softlayer-go/examples",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
 			"checksumSHA1": "tZ3W1bwC/B9lAGW7007CwaZl6C4=",
 			"path": "github.com/softlayer/softlayer-go/filter",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
 			"checksumSHA1": "iIil9KYj6J7ZEK4dG9UirsFuq1Y=",
 			"path": "github.com/softlayer/softlayer-go/helpers/location",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
-			"checksumSHA1": "6ovFRvUKPrvAa9Qhb8uZ+2HqEsA=",
+			"checksumSHA1": "G3kKx93f2BtEvrApz/xB3yy1BuQ=",
 			"path": "github.com/softlayer/softlayer-go/helpers/network",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
 			"checksumSHA1": "bGG9wihg55FY7q/kHVE5KQV8XmE=",
 			"path": "github.com/softlayer/softlayer-go/helpers/order",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
-			"checksumSHA1": "G1jjlWrEsScRsGjUW22g1K6Eetg=",
+			"checksumSHA1": "P/4mxQUWq3TBfriw7yZF3IuNdOs=",
 			"path": "github.com/softlayer/softlayer-go/helpers/product",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
 			"checksumSHA1": "AE7CLBIxLRpDneGO0RiDAifDMoM=",
 			"path": "github.com/softlayer/softlayer-go/helpers/virtual",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
-			"checksumSHA1": "DLSERKQKH62xIUIH2WypR6K4KJE=",
+			"checksumSHA1": "HZImXTbhXtn7kLns/o5gd811Qu8=",
 			"path": "github.com/softlayer/softlayer-go/meta",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
-			"checksumSHA1": "4z3WyMrjuG/ayIRrJ2wEy8qJfmc=",
+			"checksumSHA1": "VLtXK+ojrOzCuld5sTVzVD1qNP4=",
 			"path": "github.com/softlayer/softlayer-go/services",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
-			"checksumSHA1": "0h/cTKB4ojHOGut49C81IV/x4bg=",
+			"checksumSHA1": "4ua5VZBjaCJaBS6ycH75I8u3VAI=",
 			"path": "github.com/softlayer/softlayer-go/session",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		},
 		{
 			"checksumSHA1": "2jfZ4i3/2rxbFhkyRxhF0gnSvW4=",
 			"path": "github.com/softlayer/softlayer-go/sl",
-			"revision": "86c8af71077681e567ed68b4a81ae9c640108ae2",
-			"revisionTime": "2016-09-07T14:15:47Z"
+			"revision": "68b0f947a33f0931123fba726339cdfd56955f2e",
+			"revisionTime": "2016-09-08T21:33:42Z"
 		}
 	],
 	"rootPath": "github.com/softlayer/terraform-provider-softlayer"


### PR DESCRIPTION
SoftLayer_Network_Application_Delivery_Controller service provides Netscaper VPX management services. createLiveLoadBalancer, deleteLiveLoadBalancer, deleteLiveLoadBalancerService, and updateLiveLoadBalancer functions only accept one request in one Netscaler VPX at the same time. It is necessary to handle exceptions to manage concurrent requests. 

Loop and exception handling logics are added to create, update, delete functions in lb_vpx_vip and lb_vpx_service. Managed errors are as follows:
- "Operation already in progress" : Retry in 10 secs.
- "Unable to find object with unknown..." : Complete the delete operation.
- "Internal Error" : Retry in 10 secs.
- "No Service" : Retry in 10 secs. 

Test files are also updated to fix wrong test scenarios.
