### PR TITLE
Fix dns resources

### DIFF
--- a/softlayer/resource_softlayer_dns_domain.go
+++ b/softlayer/resource_softlayer_dns_domain.go
@@ -1,6 +1,7 @@
 package softlayer
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -21,112 +22,112 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 		Delete:   resourceSoftLayerDnsDomainDelete,
 		Importer: &schema.ResourceImporter{},
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"serial": &schema.Schema{
+			"serial": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
-			"update_date": &schema.Schema{
+			"update_date": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"records": &schema.Schema{
+			"records": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"record_data": &schema.Schema{
+						"record_data": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
 
-						"domain_id": &schema.Schema{
+						"domain_id": {
 							Type:     schema.TypeInt,
 							Required: true,
 							ForceNew: true,
 						},
 
-						"expire": &schema.Schema{
+						"expire": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
 
-						"host": &schema.Schema{
+						"host": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"minimum_ttl": &schema.Schema{
+						"minimum_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
 
-						"mx_priority": &schema.Schema{
+						"mx_priority": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
 
-						"refresh": &schema.Schema{
+						"refresh": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
 
-						"contact_email": &schema.Schema{
+						"contact_email": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"retry": &schema.Schema{
+						"retry": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
 
-						"ttl": &schema.Schema{
+						"ttl": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
 
-						"record_type": &schema.Schema{
+						"record_type": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
 
-						"service": &schema.Schema{
+						"service": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"protocol": &schema.Schema{
+						"protocol": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"port": &schema.Schema{
+						"port": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
 
-						"priority": &schema.Schema{
+						"priority": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
 
-						"weight": &schema.Schema{
+						"weight": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
@@ -235,7 +236,7 @@ func read_resource_records(list []datatypes.Dns_Domain_ResourceRecord) []map[str
 
 func resourceSoftLayerDnsDomainUpdate(d *schema.ResourceData, meta interface{}) error {
 	// TODO - update is not supported - implement delete-create?
-	return fmt.Errorf("Not implemented. Update Dns Domain is currently unsupported")
+	return errors.New("Not implemented. Update Dns Domain is currently unsupported")
 }
 
 func resourceSoftLayerDnsDomainDelete(d *schema.ResourceData, meta interface{}) error {
@@ -254,7 +255,7 @@ func resourceSoftLayerDnsDomainDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if !result {
-		return fmt.Errorf("Error deleting Dns Domain")
+		return errors.New("Error deleting Dns Domain")
 	}
 
 	d.SetId("")

--- a/softlayer/resource_softlayer_dns_domain.go
+++ b/softlayer/resource_softlayer_dns_domain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/softlayer/softlayer-go/datatypes"
@@ -35,7 +36,11 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 
 			"serial": {
 				Type:     schema.TypeInt,
-				Computed: true,
+				Required: true,
+				DefaultFunc: func() (interface{}, error) {
+					t := time.Now()
+					return (t.Year() * 1000000) + (int(t.Month()) * 10000) + (t.Day() * 100) + 1, nil
+				},
 			},
 
 			"update_date": {
@@ -49,16 +54,14 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"record_data": {
+						"data": {
 							Type:     schema.TypeString,
 							Required: true,
-							ForceNew: true,
 						},
 
 						"domain_id": {
 							Type:     schema.TypeInt,
-							Required: true,
-							ForceNew: true,
+							Computed: true,
 						},
 
 						"expire": {
@@ -86,9 +89,9 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 							Optional: true,
 						},
 
-						"contact_email": {
+						"responsible_person": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 
 						"retry": {
@@ -99,9 +102,10 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 						"ttl": {
 							Type:     schema.TypeInt,
 							Required: true,
+							Default: 86400,
 						},
 
-						"record_type": {
+						"type": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,

--- a/softlayer/resource_softlayer_dns_domain.go
+++ b/softlayer/resource_softlayer_dns_domain.go
@@ -11,7 +11,6 @@ import (
 	"github.com/softlayer/softlayer-go/services"
 	"github.com/softlayer/softlayer-go/session"
 	"github.com/softlayer/softlayer-go/sl"
-	"time"
 )
 
 func resourceSoftLayerDnsDomain() *schema.Resource {
@@ -34,15 +33,6 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"serial": {
-				Type:     schema.TypeInt,
-				Required: true,
-				DefaultFunc: func() (interface{}, error) {
-					t := time.Now()
-					return (t.Year() * 1000000) + (int(t.Month()) * 10000) + (t.Day() * 100) + 2, nil
-				},
-			},
-
 			"update_date": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -63,10 +53,6 @@ func resourceSoftLayerDnsDomainCreate(d *schema.ResourceData, meta interface{}) 
 	// prepare creation parameters
 	opts := datatypes.Dns_Domain{
 		Name: sl.String(d.Get("name").(string)),
-	}
-
-	if serial, ok := d.GetOk("serial"); ok {
-		opts.Serial = sl.Int(serial.(int))
 	}
 
 	// Create dns domain zone with default A record based on the target value
@@ -102,7 +88,7 @@ func resourceSoftLayerDnsDomainRead(d *schema.ResourceData, meta interface{}) er
 
 	// retrieve remote object state
 	dns_domain, err := service.Id(dnsId).Mask(
-		"id,name,serial,updateDate,resourceRecords",
+		"id,name,updateDate,resourceRecords",
 	).GetObject()
 	if err != nil {
 		return fmt.Errorf("Error retrieving Dns Domain %d: %s", dnsId, err)
@@ -110,7 +96,6 @@ func resourceSoftLayerDnsDomainRead(d *schema.ResourceData, meta interface{}) er
 
 	// populate fields
 	d.Set("name", *dns_domain.Name)
-	d.Set("serial", *dns_domain.Serial)
 	if dns_domain.UpdateDate != nil {
 		d.Set("update_date", *dns_domain.UpdateDate)
 	}

--- a/softlayer/resource_softlayer_dns_domain.go
+++ b/softlayer/resource_softlayer_dns_domain.go
@@ -101,13 +101,8 @@ func resourceSoftLayerDnsDomainRead(d *schema.ResourceData, meta interface{}) er
 
 	// populate fields
 	d.Set("name", *dns_domain.Name)
-	if dns_domain.Serial != nil {
-		d.Set("serial", *dns_domain.Serial)
-	}
-
-	if dns_domain.UpdateDate != nil {
-		d.Set("update_date", *dns_domain.UpdateDate)
-	}
+	d.Set("serial", sl.Get(dns_domain.Serial, nil))
+	d.Set("update_date", sl.Get(dns_domain.UpdateDate, nil))
 
 	// find a record with host @; that will have the current target.
 	for _, record := range dns_domain.ResourceRecords {
@@ -125,7 +120,7 @@ func resourceSoftLayerDnsDomainUpdate(d *schema.ResourceData, meta interface{}) 
 	sess := meta.(*session.Session)
 	domainId, _ := strconv.Atoi(d.Id())
 
-	if !d.HasChange("target") {
+	if !d.HasChange("target") { // target is the only editable field
 		return nil
 	}
 

--- a/softlayer/resource_softlayer_dns_domain.go
+++ b/softlayer/resource_softlayer_dns_domain.go
@@ -54,6 +54,11 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+
 						"data": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -103,7 +108,9 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 						"ttl": {
 							Type:     schema.TypeInt,
 							Required: true,
-							Default:  86400,
+							DefaultFunc: func() (interface{}, error) {
+								return 86400, nil
+							},
 						},
 
 						"type": {
@@ -192,6 +199,11 @@ func prepareRecords(raw_records []interface{}, domainId ...int) []datatypes.Dns_
 			sl_record.DomainId = sl.Int(domainId[0])
 		}
 
+		recordId := record["id"].(int)
+		if recordId != 0 {
+			sl_record.Id = sl.Int(recordId)
+		}
+
 		if *sl_record.Type == "srv" {
 			sl_record.Port = sl.Int(record["port"].(int))
 			sl_record.Priority = sl.Int(record["priority"].(int))
@@ -238,6 +250,7 @@ func read_resource_records(list []datatypes.Dns_Domain_ResourceRecord) []map[str
 		r := make(map[string]interface{})
 
 		// Required fields
+		r["id"] = *record.Id
 		r["data"] = *record.Data
 		r["domain_id"] = *record.DomainId
 		r["host"] = *record.Host

--- a/softlayer/resource_softlayer_dns_domain.go
+++ b/softlayer/resource_softlayer_dns_domain.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/softlayer/softlayer-go/datatypes"
 	"github.com/softlayer/softlayer-go/services"
 	"github.com/softlayer/softlayer-go/session"
 	"github.com/softlayer/softlayer-go/sl"
-	"strings"
 )
 
 func resourceSoftLayerDnsDomain() *schema.Resource {
@@ -37,11 +35,7 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 
 			"serial": {
 				Type:     schema.TypeInt,
-				Required: true,
-				DefaultFunc: func() (interface{}, error) {
-					t := time.Now()
-					return (t.Year() * 1000000) + (int(t.Month()) * 10000) + (t.Day() * 100) + 1, nil
-				},
+				Computed: true,
 			},
 
 			"update_date": {
@@ -280,6 +274,10 @@ func read_resource_records(list []datatypes.Dns_Domain_ResourceRecord) []map[str
 
 		if record.Retry != nil {
 			r["retry"] = *record.Retry
+		}
+
+		if record.ResponsiblePerson != nil {
+			r["responsible_person"] = *record.ResponsiblePerson
 		}
 
 		records = append([]map[string]interface{}{r}, records...)

--- a/softlayer/resource_softlayer_dns_domain.go
+++ b/softlayer/resource_softlayer_dns_domain.go
@@ -33,6 +33,11 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"serial": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"update_date": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -96,6 +101,10 @@ func resourceSoftLayerDnsDomainRead(d *schema.ResourceData, meta interface{}) er
 
 	// populate fields
 	d.Set("name", *dns_domain.Name)
+	if dns_domain.Serial != nil {
+		d.Set("serial", *dns_domain.Serial)
+	}
+
 	if dns_domain.UpdateDate != nil {
 		d.Set("update_date", *dns_domain.UpdateDate)
 	}

--- a/softlayer/resource_softlayer_dns_domain_record.go
+++ b/softlayer/resource_softlayer_dns_domain_record.go
@@ -273,56 +273,27 @@ func resourceSoftLayerDnsDomainRecordRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error retrieving DNS Resource Record: %s", err)
 	}
 
+	// Required fields
 	d.Set("data", *result.Data)
 	d.Set("domain_id", *result.DomainId)
 	d.Set("host", *result.Host)
 	d.Set("type", *result.Type)
 	d.Set("ttl", *result.Ttl)
 
-	if result.Expire != nil {
-		d.Set("expire", *result.Expire)
-	}
-
-	if result.Minimum != nil {
-		d.Set("minimum_ttl", *result.Minimum)
-	}
-
-	if result.MxPriority != nil {
-		d.Set("mx_priority", *result.MxPriority)
-	}
-
-	if result.Refresh != nil {
-		d.Set("refresh", *result.Refresh)
-	}
-
-	if result.ResponsiblePerson != nil {
-		d.Set("responsible_person", *result.ResponsiblePerson)
-	}
-
-	if result.Retry != nil {
-		d.Set("retry", *result.Retry)
-	}
+	// Optional fields
+	d.Set("expire", sl.Get(result.Expire, nil))
+	d.Set("minimum_ttl", sl.Get(result.Minimum, nil))
+	d.Set("mx_priority", sl.Get(result.MxPriority, nil))
+	d.Set("responsible_person", sl.Get(result.ResponsiblePerson, nil))
+	d.Set("refresh", sl.Get(result.Refresh, nil))
+	d.Set("retry", sl.Get(result.Retry, nil))
 
 	if *result.Type == "srv" {
-		if result.Service != nil {
-			d.Set("service", *result.Service)
-		}
-
-		if result.Protocol != nil {
-			d.Set("protocol", *result.Protocol)
-		}
-
-		if result.Port != nil {
-			d.Set("port", *result.Port)
-		}
-
-		if result.Priority != nil {
-			d.Set("priority", *result.Priority)
-		}
-
-		if result.Weight != nil {
-			d.Set("weight", *result.Weight)
-		}
+		d.Set("service", sl.Get(result.Service, nil))
+		d.Set("protocol", sl.Get(result.Protocol, nil))
+		d.Set("port", sl.Get(result.Port, nil))
+		d.Set("priority", sl.Get(result.Priority, nil))
+		d.Set("weight", sl.Get(result.Weight, nil))
 	}
 
 	return nil
@@ -341,95 +312,77 @@ func resourceSoftLayerDnsDomainRecordUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	recordType := d.Get("type").(string)
-	hasChanged := false
 
-	if data, ok := d.GetOk("data"); ok {
+	if data, ok := d.GetOk("data"); ok && d.HasChange("data") {
 		record.Data = sl.String(data.(string))
-		hasChanged = hasChanged || d.HasChange("data")
 	}
 
-	if domain_id, ok := d.GetOk("domain_id"); ok {
+	if domain_id, ok := d.GetOk("domain_id"); ok && d.HasChange("domain_id") {
 		record.DomainId = sl.Int(domain_id.(int))
-		hasChanged = hasChanged || d.HasChange("domain_id")
 	}
 
-	if host, ok := d.GetOk("host"); ok {
+	if host, ok := d.GetOk("host"); ok && d.HasChange("host") {
 		record.Host = sl.String(host.(string))
-		hasChanged = hasChanged || d.HasChange("host")
 	}
 
-	if ttl, ok := d.GetOk("ttl"); ok {
+	if ttl, ok := d.GetOk("ttl"); ok && d.HasChange("ttl") {
 		record.Ttl = sl.Int(ttl.(int))
-		hasChanged = hasChanged || d.HasChange("ttl")
 	}
 
-	if expire, ok := d.GetOk("expire"); ok {
+	if expire, ok := d.GetOk("expire"); ok && d.HasChange("expire") {
 		record.Expire = sl.Int(expire.(int))
-		hasChanged = hasChanged || d.HasChange("expire")
 	}
 
-	if minimum_ttl, ok := d.GetOk("minimum_ttl"); ok {
+	if minimum_ttl, ok := d.GetOk("minimum_ttl"); ok && d.HasChange("minimum_ttl") {
 		record.Minimum = sl.Int(minimum_ttl.(int))
-		hasChanged = hasChanged || d.HasChange("minimum_ttl")
 	}
 
-	if mx_priority, ok := d.GetOk("mx_priority"); ok {
+	if mx_priority, ok := d.GetOk("mx_priority"); ok && d.HasChange("mx_priority") {
 		record.MxPriority = sl.Int(mx_priority.(int))
-		hasChanged = hasChanged || d.HasChange("mx_priority")
 	}
 
-	if refresh, ok := d.GetOk("refresh"); ok {
+	if refresh, ok := d.GetOk("refresh"); ok && d.HasChange("refresh") {
 		record.Refresh = sl.Int(refresh.(int))
-		hasChanged = hasChanged || d.HasChange("refresh")
 	}
 
-	if contact_email, ok := d.GetOk("responsible_person"); ok {
+	if contact_email, ok := d.GetOk("responsible_person"); ok && d.HasChange("responsible_person") {
 		record.ResponsiblePerson = sl.String(contact_email.(string))
-		hasChanged = hasChanged || d.HasChange("responsible_person")
 	}
 
-	if retry, ok := d.GetOk("retry"); ok {
+	if retry, ok := d.GetOk("retry"); ok && d.HasChange("retry") {
 		record.Retry = sl.Int(retry.(int))
-		hasChanged = hasChanged || d.HasChange("retry")
 	}
 
 	recordSrv := datatypes.Dns_Domain_ResourceRecord_SrvType{
 		Dns_Domain_ResourceRecord: record,
 	}
 	if recordType == "srv" {
-		if service, ok := d.GetOk("service"); ok {
+		if service, ok := d.GetOk("service"); ok && d.HasChange("service") {
 			recordSrv.Service = sl.String(service.(string))
-			hasChanged = hasChanged || d.HasChange("service")
 		}
 
-		if priority, ok := d.GetOk("priority"); ok {
+		if priority, ok := d.GetOk("priority"); ok && d.HasChange("priority") {
 			recordSrv.Priority = sl.Int(priority.(int))
-			hasChanged = hasChanged || d.HasChange("priority")
 		}
 
-		if protocol, ok := d.GetOk("protocol"); ok {
+		if protocol, ok := d.GetOk("protocol"); ok && d.HasChange("protocol") {
 			recordSrv.Protocol = sl.String(protocol.(string))
-			hasChanged = hasChanged || d.HasChange("protocol")
 		}
 
-		if port, ok := d.GetOk("port"); ok {
+		if port, ok := d.GetOk("port"); ok && d.HasChange("port") {
 			recordSrv.Port = sl.Int(port.(int))
-			hasChanged = hasChanged || d.HasChange("port")
 		}
 
-		if weight, ok := d.GetOk("weight"); ok {
+		if weight, ok := d.GetOk("weight"); ok && d.HasChange("weight") {
 			recordSrv.Weight = sl.Int(weight.(int))
-			hasChanged = hasChanged || d.HasChange("weight")
 		}
 	}
 
-	if hasChanged {
-		if recordType == "srv" {
-			_, err = services.GetDnsDomainResourceRecordSrvTypeService(sess).
-				Id(recordId).EditObject(&recordSrv)
-		} else {
-			_, err = service.Id(recordId).EditObject(&record)
-		}
+	if recordType == "srv" {
+		_, err = services.GetDnsDomainResourceRecordSrvTypeService(sess).
+			Id(recordId).EditObject(&recordSrv)
+	} else {
+		_, err = service.Id(recordId).EditObject(&record)
 	}
 
 	if err != nil {

--- a/softlayer/resource_softlayer_dns_domain_record.go
+++ b/softlayer/resource_softlayer_dns_domain_record.go
@@ -21,85 +21,97 @@ func resourceSoftLayerDnsDomainRecord() *schema.Resource {
 		Delete:   resourceSoftLayerDnsDomainRecordDelete,
 		Importer: &schema.ResourceImporter{},
 		Schema: map[string]*schema.Schema{
-			"record_data": &schema.Schema{
+			"id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"data": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"domain_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"expire": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"host": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"mx_priority": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  10,
+			},
+
+			"refresh": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"responsible_person": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"retry": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"minimum_ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"ttl": {
+				Type:     schema.TypeInt,
+				Required: true,
+				DefaultFunc: func() (interface{}, error) {
+					return 86400, nil
+				},
+			},
+
+			"type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"domain_id": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"expire": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-
-			"host": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"minimum_ttl": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-
-			"mx_priority": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-
-			"refresh": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-
-			"contact_email": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"retry": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-
-			"ttl": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-
-			"record_type": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"service": &schema.Schema{
+			"service": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"protocol": &schema.Schema{
+			"protocol": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"port": &schema.Schema{
+			"port": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
 
-			"priority": &schema.Schema{
+			"priority": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
 
-			"weight": &schema.Schema{
+			"weight": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},

--- a/softlayer/resource_softlayer_dns_domain_record.go
+++ b/softlayer/resource_softlayer_dns_domain_record.go
@@ -127,11 +127,11 @@ func resourceSoftLayerDnsDomainRecordCreate(d *schema.ResourceData, meta interfa
 	service := services.GetDnsDomainResourceRecordService(sess)
 
 	opts := datatypes.Dns_Domain_ResourceRecord{
-		Data:              sl.String(d.Get("data").(string)),
-		DomainId:          sl.Int(d.Get("domain_id").(int)),
-		Host:              sl.String(d.Get("host").(string)),
-		Ttl:               sl.Int(d.Get("ttl").(int)),
-		Type:              sl.String(d.Get("type").(string)),
+		Data:     sl.String(d.Get("data").(string)),
+		DomainId: sl.Int(d.Get("domain_id").(int)),
+		Host:     sl.String(d.Get("host").(string)),
+		Ttl:      sl.Int(d.Get("ttl").(int)),
+		Type:     sl.String(d.Get("type").(string)),
 	}
 
 	if expire, ok := d.GetOk("expire"); ok {

--- a/softlayer/resource_softlayer_dns_domain_record.go
+++ b/softlayer/resource_softlayer_dns_domain_record.go
@@ -270,107 +270,93 @@ func resourceSoftLayerDnsDomainRecordUpdate(d *schema.ResourceData, meta interfa
 	sess := meta.(*session.Session)
 	recordId, _ := strconv.Atoi(d.Id())
 
-	if d.Get("type").(string) == "srv" {
-		service := services.GetDnsDomainResourceRecordSrvTypeService(sess)
-		record, err := service.Id(recordId).GetObject()
-		if err != nil {
-			return fmt.Errorf("Error retrieving DNS Resource SRV Record: %s", err)
-		}
+	service := services.GetDnsDomainResourceRecordService(sess)
+	record, err := service.Id(recordId).GetObject()
+	if err != nil {
+		return fmt.Errorf("Error retrieving DNS Resource Record: %s", err)
+	}
 
-		if data, ok := d.GetOk("record_data"); ok {
-			record.Data = sl.String(data.(string))
-		}
-		if domain_id, ok := d.GetOk("domain_id"); ok {
-			record.DomainId = sl.Int(domain_id.(int))
-		}
-		if expire, ok := d.GetOk("expire"); ok {
-			record.Expire = sl.Int(expire.(int))
-		}
-		if host, ok := d.GetOk("host"); ok {
-			record.Host = sl.String(host.(string))
-		}
-		if minimum_ttl, ok := d.GetOk("minimum_ttl"); ok {
-			record.Minimum = sl.Int(minimum_ttl.(int))
-		}
-		if mx_priority, ok := d.GetOk("mx_priority"); ok {
-			record.MxPriority = sl.Int(mx_priority.(int))
-		}
-		if refresh, ok := d.GetOk("refresh"); ok {
-			record.Refresh = sl.Int(refresh.(int))
-		}
-		if contact_email, ok := d.GetOk("contact_email"); ok {
-			record.ResponsiblePerson = sl.String(contact_email.(string))
-		}
-		if retry, ok := d.GetOk("retry"); ok {
-			record.Retry = sl.Int(retry.(int))
-		}
-		if ttl, ok := d.GetOk("ttl"); ok {
-			record.Ttl = sl.Int(ttl.(int))
-		}
-		if record_type, ok := d.GetOk("record_type"); ok {
-			record.Type = sl.String(record_type.(string))
-		}
+	recordType := d.Get("type").(string)
+	hasChanged := false
+
+	if data, ok := d.GetOk("data"); ok {
+		record.Data = sl.String(data.(string))
+		hasChanged = hasChanged || d.HasChange("data")
+	}
+
+	if domain_id, ok := d.GetOk("domain_id"); ok {
+		record.DomainId = sl.Int(domain_id.(int))
+		hasChanged = hasChanged || d.HasChange("domain_id")
+	}
+
+	if host, ok := d.GetOk("host"); ok {
+		record.Host = sl.String(host.(string))
+		hasChanged = hasChanged || d.HasChange("host")
+	}
+
+	if ttl, ok := d.GetOk("ttl"); ok {
+		record.Ttl = sl.Int(ttl.(int))
+		hasChanged = hasChanged || d.HasChange("ttl")
+	}
+
+	if expire, ok := d.GetOk("expire"); ok {
+		record.Expire = sl.Int(expire.(int))
+		hasChanged = hasChanged || d.HasChange("expire")
+	}
+
+	if minimum_ttl, ok := d.GetOk("minimum_ttl"); ok {
+		record.Minimum = sl.Int(minimum_ttl.(int))
+		hasChanged = hasChanged || d.HasChange("minimum_ttl")
+	}
+
+	if mx_priority, ok := d.GetOk("mx_priority"); ok {
+		record.MxPriority = sl.Int(mx_priority.(int))
+		hasChanged = hasChanged || d.HasChange("mx_priority")
+	}
+
+	if refresh, ok := d.GetOk("refresh"); ok {
+		record.Refresh = sl.Int(refresh.(int))
+		hasChanged = hasChanged || d.HasChange("refresh")
+	}
+
+	if contact_email, ok := d.GetOk("responsible_person"); ok {
+		record.ResponsiblePerson = sl.String(contact_email.(string))
+		hasChanged = hasChanged || d.HasChange("responsible_person")
+	}
+
+	if retry, ok := d.GetOk("retry"); ok {
+		record.Retry = sl.Int(retry.(int))
+		hasChanged = hasChanged || d.HasChange("retry")
+	}
+
+	if recordType == "srv" {
 		if service, ok := d.GetOk("service"); ok {
 			record.Service = sl.String(service.(string))
+			hasChanged = hasChanged || d.HasChange("service")
 		}
+
 		if priority, ok := d.GetOk("priority"); ok {
 			record.Priority = sl.Int(priority.(int))
+			hasChanged = hasChanged || d.HasChange("priority")
 		}
+
 		if protocol, ok := d.GetOk("protocol"); ok {
 			record.Protocol = sl.String(protocol.(string))
+			hasChanged = hasChanged || d.HasChange("protocol")
 		}
+
 		if port, ok := d.GetOk("port"); ok {
 			record.Port = sl.Int(port.(int))
+			hasChanged = hasChanged || d.HasChange("port")
 		}
+
 		if weight, ok := d.GetOk("weight"); ok {
 			record.Weight = sl.Int(weight.(int))
+			hasChanged = hasChanged || d.HasChange("weight")
 		}
+	}
 
-		_, err = service.Id(recordId).EditObject(&record)
-		if err != nil {
-			return fmt.Errorf("Error editing DNS Resoource SRV Record: %s", err)
-		}
-	} else {
-		service := services.GetDnsDomainResourceRecordService(sess)
-		record, err := service.Id(recordId).GetObject()
-		if err != nil {
-			return fmt.Errorf("Error retrieving DNS Resource Record: %s", err)
-		}
-
-		if data, ok := d.GetOk("record_data"); ok {
-			record.Data = sl.String(data.(string))
-		}
-		if domain_id, ok := d.GetOk("domain_id"); ok {
-			record.DomainId = sl.Int(domain_id.(int))
-		}
-		if expire, ok := d.GetOk("expire"); ok {
-			record.Expire = sl.Int(expire.(int))
-		}
-		if host, ok := d.GetOk("host"); ok {
-			record.Host = sl.String(host.(string))
-		}
-		if minimum_ttl, ok := d.GetOk("minimum_ttl"); ok {
-			record.Minimum = sl.Int(minimum_ttl.(int))
-		}
-		if mx_priority, ok := d.GetOk("mx_priority"); ok {
-			record.MxPriority = sl.Int(mx_priority.(int))
-		}
-		if refresh, ok := d.GetOk("refresh"); ok {
-			record.Refresh = sl.Int(refresh.(int))
-		}
-		if contact_email, ok := d.GetOk("contact_email"); ok {
-			record.ResponsiblePerson = sl.String(contact_email.(string))
-		}
-		if retry, ok := d.GetOk("retry"); ok {
-			record.Retry = sl.Int(retry.(int))
-		}
-		if ttl, ok := d.GetOk("ttl"); ok {
-			record.Ttl = sl.Int(ttl.(int))
-		}
-		if record_type, ok := d.GetOk("record_type"); ok {
-			record.Type = sl.String(record_type.(string))
-		}
-
+	if hasChanged {
 		_, err = service.Id(recordId).EditObject(&record)
 		if err != nil {
 			return fmt.Errorf("Error editing DNS Resoource Record: %s", err)

--- a/softlayer/resource_softlayer_dns_domain_record.go
+++ b/softlayer/resource_softlayer_dns_domain_record.go
@@ -118,6 +118,22 @@ func resourceSoftLayerDnsDomainRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: func(val interface{}, field string) (warnings []string, errors []error) {
+					value := val.(string)
+					for _, rtype := range allowedDomainRecordTypes {
+						if value == rtype {
+							return
+						}
+					}
+
+					errors = append(
+						errors,
+						fmt.Errorf("%s is not one of the valid domain record types: %s",
+							value, strings.Join(allowedDomainRecordTypes, ", "),
+						),
+					)
+					return
+				},
 			},
 
 			"service": {

--- a/softlayer/resource_softlayer_dns_domain_record_test.go
+++ b/softlayer/resource_softlayer_dns_domain_record_test.go
@@ -53,17 +53,24 @@ func TestAccSoftLayerDnsDomainRecord_Types(t *testing.T) {
 		CheckDestroy: testAccCheckSoftLayerDnsDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckSoftLayerDnsDomainRecordConfig_all_types,
+				Config: fmt.Sprintf(testAccCheckSoftLayerDnsDomainRecordConfig_all_types, "_tcp"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.test_dns_domain_record_types", &dns_domain),
 					testAccCheckSoftLayerDnsDomainRecordExists("softlayer_dns_domain_record.recordA", &dns_domain_record),
 					testAccCheckSoftLayerDnsDomainRecordExists("softlayer_dns_domain_record.recordAAAA", &dns_domain_record),
 					testAccCheckSoftLayerDnsDomainRecordExists("softlayer_dns_domain_record.recordCNAME", &dns_domain_record),
 					testAccCheckSoftLayerDnsDomainRecordExists("softlayer_dns_domain_record.recordMX", &dns_domain_record),
-					testAccCheckSoftLayerDnsDomainRecordExists("softlayer_dns_domain_record.recordNS", &dns_domain_record),
 					testAccCheckSoftLayerDnsDomainRecordExists("softlayer_dns_domain_record.recordSPF", &dns_domain_record),
 					testAccCheckSoftLayerDnsDomainRecordExists("softlayer_dns_domain_record.recordTXT", &dns_domain_record),
 					testAccCheckSoftLayerDnsDomainRecordExists("softlayer_dns_domain_record.recordSRV", &dns_domain_record),
+				),
+				Destroy: false,
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckSoftLayerDnsDomainRecordConfig_all_types, "_udp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.test_dns_domain_record_types", &dns_domain),
+					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordSRV", "protocol", "_udp"),
 				),
 				Destroy: false,
 			},
@@ -116,7 +123,7 @@ resource "softlayer_dns_domain_record" "recordA" {
     mx_priority = 1
     refresh = 1
     host = "hosta.com"
-    responsible_person = "user@softlaer.com"
+    responsible_person = "user@softlayer.com"
     ttl = 900
     retry = 1
     type = "a"
@@ -132,16 +139,16 @@ resource "softlayer_dns_domain_record" "recordA" {
     data = "127.0.0.1"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta.com"
-    responsible_person = "user@softlaer.com"
+    responsible_person = "user@softlayer.com"
     ttl = 900
     type = "a"
 }
 
 resource "softlayer_dns_domain_record" "recordAAAA" {
-    data = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
+    data = "fe80:0000:0000:0000:0202:b3ff:fe1e:8329"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-2.com"
-    responsible_person = "user2changed@softlaer.com"
+    responsible_person = "user2changed@softlayer.com"
     ttl = 1000
     type = "aaaa"
 }
@@ -150,7 +157,7 @@ resource "softlayer_dns_domain_record" "recordCNAME" {
     data = "testsssaaaass.com"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-cname.com"
-    responsible_person = "user@softlaer.com"
+    responsible_person = "user@softlayer.com"
     ttl = 900
     type = "cname"
 }
@@ -159,25 +166,16 @@ resource "softlayer_dns_domain_record" "recordMX" {
     data = "email.example.com"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-mx.com"
-    responsible_person = "user@softlaer.com"
+    responsible_person = "user@softlayer.com"
     ttl = 900
     type = "mx"
-}
-
-resource "softlayer_dns_domain_record" "recordNS" {
-    data = "ns1.example.org"
-    domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
-    host = "hosta-ns.com"
-    responsible_person = "user@softlaer.com"
-    ttl = 900
-    type = "ns"
 }
 
 resource "softlayer_dns_domain_record" "recordSPF" {
     data = "v=spf1 mx:mail.example.org ~all"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-spf"
-    responsible_person = "user@softlaer.com"
+    responsible_person = "user@softlayer.com"
     ttl = 900
     type = "spf"
 }
@@ -186,7 +184,7 @@ resource "softlayer_dns_domain_record" "recordTXT" {
     data = "127.0.0.1"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-txt.com"
-    responsible_person = "user@softlaer.com"
+    responsible_person = "user@softlayer.com"
     ttl = 900
     type = "txt"
 }
@@ -195,12 +193,12 @@ resource "softlayer_dns_domain_record" "recordSRV" {
     data = "ns1.example.org"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-srv.com"
-    responsible_person = "user@softlaer.com"
+    responsible_person = "user@softlayer.com"
     ttl = 900
     type = "srv"
 	port = 8080
 	priority = 3
-	protocol = "_tcp"
+	protocol = "%s"
 	weight = 3
 	service = "_mail"
 }

--- a/softlayer/resource_softlayer_dns_domain_record_test.go
+++ b/softlayer/resource_softlayer_dns_domain_record_test.go
@@ -1,6 +1,7 @@
 package softlayer
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -21,21 +22,21 @@ func TestAccSoftLayerDnsDomainRecord_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSoftLayerDnsDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckSoftLayerDnsDomainRecordConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.test_dns_domain_records", &dns_domain),
 					testAccCheckSoftLayerDnsDomainRecordExists("softlayer_dns_domain_record.recordA", &dns_domain_record),
-					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "record_data", "127.0.0.1"),
+					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "data", "127.0.0.1"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "expire", "900"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "minimum_ttl", "90"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "mx_priority", "1"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "refresh", "1"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "host", "hosta.com"),
-					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "contact_email", "user@softlaer.com"),
+					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "responsible_person", "user@softlaer.com"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "ttl", "900"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "retry", "1"),
-					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "record_type", "a"),
+					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "type", "a"),
 				),
 			},
 		},
@@ -51,7 +52,7 @@ func TestAccSoftLayerDnsDomainRecord_Types(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSoftLayerDnsDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckSoftLayerDnsDomainRecordConfig_all_types,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.test_dns_domain_record_types", &dns_domain),
@@ -79,7 +80,7 @@ func testAccCheckSoftLayerDnsDomainRecordExists(n string, dns_domain_record *dat
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Record ID is set")
+			return errors.New("No Record ID is set")
 		}
 
 		dns_id, _ := strconv.Atoi(rs.Primary.ID)
@@ -92,7 +93,7 @@ func testAccCheckSoftLayerDnsDomainRecordExists(n string, dns_domain_record *dat
 		}
 
 		if strconv.Itoa(int(*found_domain_record.Id)) != rs.Primary.ID {
-			return fmt.Errorf("Record not found")
+			return fmt.Errorf("Record %d not found", dns_id)
 		}
 
 		*dns_domain_record = found_domain_record
@@ -104,97 +105,99 @@ func testAccCheckSoftLayerDnsDomainRecordExists(n string, dns_domain_record *dat
 var testAccCheckSoftLayerDnsDomainRecordConfig_basic = `
 resource "softlayer_dns_domain" "test_dns_domain_records" {
 	name = "domain.records.com"
+	target = "172.16.0.100"
 }
 
 resource "softlayer_dns_domain_record" "recordA" {
-    record_data = "127.0.0.1"
+    data = "127.0.0.1"
     domain_id = "${softlayer_dns_domain.test_dns_domain_records.id}"
     expire = 900
     minimum_ttl = 90
     mx_priority = 1
     refresh = 1
     host = "hosta.com"
-    contact_email = "user@softlaer.com"
+    responsible_person = "user@softlaer.com"
     ttl = 900
     retry = 1
-    record_type = "a"
+    type = "a"
 }
 `
 var testAccCheckSoftLayerDnsDomainRecordConfig_all_types = `
 resource "softlayer_dns_domain" "test_dns_domain_record_types" {
-	name = "domaint.record.types.com"
+	name = "domain.record.types.com"
+	target = "172.16.0.100"
 }
 
 resource "softlayer_dns_domain_record" "recordA" {
-    record_data = "127.0.0.1"
+    data = "127.0.0.1"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta.com"
-    contact_email = "user@softlaer.com"
+    responsible_person = "user@softlaer.com"
     ttl = 900
-    record_type = "a"
+    type = "a"
 }
 
 resource "softlayer_dns_domain_record" "recordAAAA" {
-    record_data = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
+    data = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-2.com"
-    contact_email = "user2changed@softlaer.com"
+    responsible_person = "user2changed@softlaer.com"
     ttl = 1000
-    record_type = "aaaa"
+    type = "aaaa"
 }
 
 resource "softlayer_dns_domain_record" "recordCNAME" {
-    record_data = "testsssaaaass.com"
+    data = "testsssaaaass.com"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-cname.com"
-    contact_email = "user@softlaer.com"
+    responsible_person = "user@softlaer.com"
     ttl = 900
-    record_type = "cname"
+    type = "cname"
 }
 
 resource "softlayer_dns_domain_record" "recordMX" {
-    record_data = "email.example.com"
+    data = "email.example.com"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-mx.com"
-    contact_email = "user@softlaer.com"
+    responsible_person = "user@softlaer.com"
     ttl = 900
-    record_type = "mx"
+    type = "mx"
 }
 
 resource "softlayer_dns_domain_record" "recordNS" {
-    record_data = "ns1.example.org"
+    data = "ns1.example.org"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-ns.com"
-    contact_email = "user@softlaer.com"
+    responsible_person = "user@softlaer.com"
     ttl = 900
-    record_type = "ns"
+    type = "ns"
 }
 
 resource "softlayer_dns_domain_record" "recordSPF" {
-    record_data = "v=spf1 mx:mail.example.org ~all"
+    data = "v=spf1 mx:mail.example.org ~all"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-spf"
-    contact_email = "user@softlaer.com"
+    responsible_person = "user@softlaer.com"
     ttl = 900
-    record_type = "spf"
+    type = "spf"
 }
 
 resource "softlayer_dns_domain_record" "recordTXT" {
-    record_data = "127.0.0.1"
+    data = "127.0.0.1"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-txt.com"
-    contact_email = "user@softlaer.com"
+    responsible_person = "user@softlaer.com"
     ttl = 900
-    record_type = "txt"
+    type = "txt"
 }
 
 resource "softlayer_dns_domain_record" "recordSRV" {
-    record_data = "ns1.example.org"
+    data = "ns1.example.org"
     domain_id = "${softlayer_dns_domain.test_dns_domain_record_types.id}"
     host = "hosta-srv.com"
-    contact_email = "user@softlaer.com"
+    responsible_person = "user@softlaer.com"
     ttl = 900
-    record_type = "srv"
+    type = "srv"
 	port = 8080
 	priority = 3
 	protocol = "_tcp"

--- a/softlayer/resource_softlayer_dns_domain_record_test.go
+++ b/softlayer/resource_softlayer_dns_domain_record_test.go
@@ -33,7 +33,7 @@ func TestAccSoftLayerDnsDomainRecord_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "mx_priority", "1"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "refresh", "1"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "host", "hosta.com"),
-					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "responsible_person", "user@softlaer.com"),
+					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "responsible_person", "user@softlayer.com"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "ttl", "900"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "retry", "1"),
 					resource.TestCheckResourceAttr("softlayer_dns_domain_record.recordA", "type", "a"),

--- a/softlayer/resource_softlayer_dns_domain_test.go
+++ b/softlayer/resource_softlayer_dns_domain_test.go
@@ -53,7 +53,7 @@ func TestAccSoftLayerDnsDomain_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_dns_domain.acceptance_test_dns_domain-1",
 						"records.1.data",
-						"FE80:0000:0000:0000:0202:B3FF:FE1E:8329",
+						"fe80:0000:0000:0000:0202:b3ff:fe1e:8329",
 					),
 					resource.TestCheckResourceAttr(
 						"softlayer_dns_domain.acceptance_test_dns_domain-1",
@@ -96,7 +96,7 @@ func TestAccSoftLayerDnsDomain_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_dns_domain.acceptance_test_dns_domain-1",
 						"records.1.data",
-						"FE80:0000:0000:0000:0202:B3FF:FE1E:8329",
+						"fe80:0000:0000:0000:0202:b3ff:fe1e:8329",
 					),
 					resource.TestCheckResourceAttr(
 						"softlayer_dns_domain.acceptance_test_dns_domain-1",
@@ -243,7 +243,7 @@ func testAccCheckSoftLayerDnsDomainRecordsExists(dn string, expected_record_coun
 		dns_id, _ := strconv.Atoi(rs.Primary.ID)
 
 		service := services.GetDnsDomainService(testAccProvider.Meta().(*session.Session))
-		found_domain, err := service.Id(dns_id).GetObject()
+		found_domain, err := service.Id(dns_id).Mask("id,resourceRecordCount").GetObject()
 
 		if err != nil {
 			return err
@@ -286,7 +286,7 @@ resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 var testAccCheckSoftLayerDnsDomainConfig_changed = fmt.Sprintf(`
 resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 	name = "%s"
-	serial = "%s"
+	serial = %d
 	records = [
 		{
 			data = "127.0.0.2"
@@ -296,7 +296,7 @@ resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 			type = "a"
 		},
 		{
-			data = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
+			data = "fe80:0000:0000:0000:0202:b3ff:fe1e:8329"
 			host = "hosta-2.com"
 			responsible_person = "user2changed@softlaer.com"
 			ttl = 1000

--- a/softlayer/resource_softlayer_dns_domain_test.go
+++ b/softlayer/resource_softlayer_dns_domain_test.go
@@ -204,20 +204,6 @@ resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 }
 `
 
-//var testAccCheckSoftLayerDnsDomainConfig_basic = fmt.Sprintf(`
-//resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
-//	name = "%s"
-//	target = "%s"
-//}
-//`, test_dns_domain_name, target1)
-//
-//var testAccCheckSoftLayerDnsDomainConfig_changed = fmt.Sprintf(`
-//resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
-//	name = "%s"
-//	target = "%s"
-//}
-//`, changed_dns_domain_name, target1)
-
 var domainName1 = "zxczcxzxc.com"
 var domainName2 = "vbnvnvbnv.com"
 var target1 = "172.16.0.100"

--- a/softlayer/resource_softlayer_dns_domain_test.go
+++ b/softlayer/resource_softlayer_dns_domain_test.go
@@ -21,7 +21,7 @@ func TestAccSoftLayerDnsDomain_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSoftLayerDnsDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckSoftLayerDnsDomainConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
@@ -47,7 +47,7 @@ func TestAccSoftLayerDnsDomain_Basic(t *testing.T) {
 				),
 				Destroy: false,
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckSoftLayerDnsDomainConfig_changed,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
@@ -107,7 +107,7 @@ func testAccCheckSoftLayerDnsDomainRecordDomainId(n string, dns_domain *datatype
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Record ID is set")
+			return errors.New("No Record ID is set")
 		}
 
 		id, _ := strconv.Atoi(rs.Primary.Attributes["domain_id"])
@@ -123,7 +123,7 @@ func testAccCheckSoftLayerDnsDomainAttributes(dns *datatypes.Dns_Domain) resourc
 	return func(s *terraform.State) error {
 
 		if *dns.Name == "" {
-			return fmt.Errorf("Empty dns domain name")
+			return errors.New("Empty dns domain name")
 		}
 
 		if *dns.Serial == 0 {
@@ -168,7 +168,7 @@ func testAccCheckSoftLayerDnsDomainExists(n string, dns_domain *datatypes.Dns_Do
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Record ID is set")
+			return errors.New("No Record ID is set")
 		}
 
 		dns_id, _ := strconv.Atoi(rs.Primary.ID)
@@ -181,7 +181,7 @@ func testAccCheckSoftLayerDnsDomainExists(n string, dns_domain *datatypes.Dns_Do
 		}
 
 		if strconv.Itoa(int(*found_domain.Id)) != rs.Primary.ID {
-			return fmt.Errorf("Record not found")
+			return errors.New("Record not found")
 		}
 
 		*dns_domain = found_domain
@@ -199,7 +199,7 @@ func testAccCheckSoftLayerDnsDomainRecordsExists(dn string, expected_record_coun
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Record ID is set")
+			return errors.New("No Record ID is set")
 		}
 
 		dns_id, _ := strconv.Atoi(rs.Primary.ID)
@@ -216,7 +216,7 @@ func testAccCheckSoftLayerDnsDomainRecordsExists(dn string, expected_record_coun
 		}
 
 		if strconv.Itoa(int(*found_domain.Id)) != rs.Primary.ID {
-			return fmt.Errorf("Record not found")
+			return errors.New("Record not found")
 		}
 
 		return nil

--- a/softlayer/resource_softlayer_dns_domain_test.go
+++ b/softlayer/resource_softlayer_dns_domain_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/softlayer/softlayer-go/datatypes"
 	"github.com/softlayer/softlayer-go/services"
 	"github.com/softlayer/softlayer-go/session"
+	"github.com/softlayer/softlayer-go/sl"
 )
 
 func TestAccSoftLayerDnsDomain_Basic(t *testing.T) {
@@ -26,23 +27,39 @@ func TestAccSoftLayerDnsDomain_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
 					testAccCheckSoftLayerDnsDomainAttributes(&dns_domain),
-					testAccCheckSoftLayerDnsDomainRecordDomainId("softlayer_dns_domain_record.recordA", &dns_domain),
-					testAccCheckSoftLayerDnsDomainRecordDomainId("softlayer_dns_domain_record.recordAAAA", &dns_domain),
 					saveSoftLayerDnsDomainId(&dns_domain, &firstDnsId),
 					resource.TestCheckResourceAttr(
 						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", test_dns_domain_name),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordA", "host", "hosta.com"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.0.host",
+						"hosta.com",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordA", "record_data", "127.0.0.1"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.0.data",
+						"127.0.0.1",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordA", "record_type", "a"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.0.type",
+						"a",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordAAAA", "host", "hosta-2.com"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.1.host",
+						"hosta-2.com",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordAAAA", "record_data", "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.1.data",
+						"FE80:0000:0000:0000:0202:B3FF:FE1E:8329",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordAAAA", "record_type", "aaaa"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.1.type",
+						"aaaa",
+					),
 					testAccCheckSoftLayerDnsDomainRecordsExists("softlayer_dns_domain.acceptance_test_dns_domain-1", 5),
 				),
 				Destroy: false,
@@ -52,22 +69,40 @@ func TestAccSoftLayerDnsDomain_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
 					testAccCheckSoftLayerDnsDomainAttributes(&dns_domain),
-					testAccCheckSoftLayerDnsDomainRecordDomainId("softlayer_dns_domain_record.recordA", &dns_domain),
-					testAccCheckSoftLayerDnsDomainRecordDomainId("softlayer_dns_domain_record.recordAAAA", &dns_domain),
+					testAccCheckSoftLayerDnsDomainRecordDomainId(
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", changed_dns_domain_name),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", test_dns_domain_name),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordA", "host", "hosta.com"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.0.host",
+						"hosta.com",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordA", "record_data", "127.0.0.1"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.0.data",
+						"127.0.0.2",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordA", "record_type", "a"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.0.type",
+						"a",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordAAAA", "host", "hosta-2.com"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.1.host",
+						"hosta-2.com",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordAAAA", "record_data", "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.1.data",
+						"FE80:0000:0000:0000:0202:B3FF:FE1E:8329",
+					),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain_record.recordAAAA", "record_type", "aaaa"),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1",
+						"records.1.type",
+						"aaaa",
+					),
 					testAccCheckSoftLayerDnsDomainRecordsExists("softlayer_dns_domain.acceptance_test_dns_domain-1", 5),
 					testAccCheckSoftLayerDnsDomainChanged(&dns_domain),
 				),
@@ -106,13 +141,16 @@ func testAccCheckSoftLayerDnsDomainRecordDomainId(n string, dns_domain *datatype
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return errors.New("No Record ID is set")
-		}
-
-		id, _ := strconv.Atoi(rs.Primary.Attributes["domain_id"])
-		if *dns_domain.Id != id {
-			return fmt.Errorf("Dns domain id (%d) and Dns domain record domain id (%d) should be equal", *dns_domain.Id, id)
+		attrs := rs.Primary.Attributes
+		recordsTotal, _ := strconv.Atoi(attrs["records.#"])
+		for i := 0; i < recordsTotal; i++ {
+			recordDomainId, _ := strconv.Atoi(attrs[fmt.Sprintf("records.%d.domain_id", i)])
+			if *dns_domain.Id != recordDomainId {
+				return fmt.Errorf(
+					"Dns domain id (%d) and Dns domain record domain id (%d) should be equal",
+					*dns_domain.Id, recordDomainId,
+				)
+			}
 		}
 
 		return nil
@@ -122,16 +160,16 @@ func testAccCheckSoftLayerDnsDomainRecordDomainId(n string, dns_domain *datatype
 func testAccCheckSoftLayerDnsDomainAttributes(dns *datatypes.Dns_Domain) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if *dns.Name == "" {
+		if name := sl.Get(dns.Name); name == "" {
 			return errors.New("Empty dns domain name")
 		}
 
-		if *dns.Serial == 0 {
-			return fmt.Errorf("Bad dns domain serial: %d", *dns.Serial)
+		if serial := sl.Get(dns.Serial); serial == 0 {
+			return fmt.Errorf("Bad dns domain serial: %d", serial)
 		}
 
-		if *dns.Id == 0 {
-			return fmt.Errorf("Bad dns domain id: %d", *dns.Id)
+		if id := sl.Get(dns.Id); id == 0 {
+			return fmt.Errorf("Bad dns domain id: %d", id)
 		}
 
 		return nil
@@ -226,51 +264,48 @@ func testAccCheckSoftLayerDnsDomainRecordsExists(dn string, expected_record_coun
 var testAccCheckSoftLayerDnsDomainConfig_basic = fmt.Sprintf(`
 resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 	name = "%s"
-}
-
-resource "softlayer_dns_domain_record" "recordA" {
-    record_data = "127.0.0.1"
-    domain_id = "${softlayer_dns_domain.acceptance_test_dns_domain-1.id}"
-    host = "hosta.com"
-    contact_email = "user@softlaer.com"
-    ttl = 900
-    record_type = "a"
-}
-
-resource "softlayer_dns_domain_record" "recordAAAA" {
-    record_data = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
-    domain_id = "${softlayer_dns_domain.acceptance_test_dns_domain-1.id}"
-    host = "hosta-2.com"
-    contact_email = "user2changed@softlaer.com"
-    ttl = 1000
-    record_type = "aaaa"
+	records = [
+		{
+			data = "127.0.0.1"
+			host = "hosta.com"
+			responsible_person = "user@softlaer.com"
+			ttl = 900
+			type = "a"
+		},
+		{
+			data = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
+			host = "hosta-2.com"
+			responsible_person = "user2changed@softlaer.com"
+			ttl = 1000
+			type = "aaaa"
+		}
+	]
 }
 `, test_dns_domain_name)
 
 var testAccCheckSoftLayerDnsDomainConfig_changed = fmt.Sprintf(`
 resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 	name = "%s"
+	serial = "%s"
+	records = [
+		{
+			data = "127.0.0.2"
+			host = "hosta.com"
+			responsible_person = "user@softlaer.com"
+			ttl = 900
+			type = "a"
+		},
+		{
+			data = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
+			host = "hosta-2.com"
+			responsible_person = "user2changed@softlaer.com"
+			ttl = 1000
+			type = "aaaa"
+		}
+	]
 }
-
-resource "softlayer_dns_domain_record" "recordA" {
-    record_data = "127.0.0.1"
-    domain_id = "${softlayer_dns_domain.acceptance_test_dns_domain-1.id}"
-    host = "hosta.com"
-    contact_email = "user@softlaer.com"
-    ttl = 900
-    record_type = "a"
-}
-
-resource "softlayer_dns_domain_record" "recordAAAA" {
-    record_data = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
-    domain_id = "${softlayer_dns_domain.acceptance_test_dns_domain-1.id}"
-    host = "hosta-2.com"
-    contact_email = "user2changed@softlaer.com"
-    ttl = 1000
-    record_type = "aaaa"
-}
-`, changed_dns_domain_name)
+`, test_dns_domain_name, changed_serial)
 
 var test_dns_domain_name = "zxczcxzxc.com"
-var changed_dns_domain_name = "vbnvnvbnv.com"
+var changed_serial = 1234567890
 var firstDnsId = 0

--- a/softlayer/resource_softlayer_dns_domain_test.go
+++ b/softlayer/resource_softlayer_dns_domain_test.go
@@ -72,7 +72,7 @@ func TestAccSoftLayerDnsDomain_Basic(t *testing.T) {
 					testAccCheckSoftLayerDnsDomainRecordDomainId(
 						"softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", test_dns_domain_name),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", changed_dns_domain_name),
 					resource.TestCheckResourceAttr(
 						"softlayer_dns_domain.acceptance_test_dns_domain-1",
 						"records.0.host",
@@ -268,14 +268,14 @@ resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 		{
 			data = "127.0.0.1"
 			host = "hosta.com"
-			responsible_person = "user@softlaer.com"
+			responsible_person = "user@softlayer.com"
 			ttl = 900
 			type = "a"
 		},
 		{
-			data = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
+			data = "fe80:0000:0000:0000:0202:b3ff:fe1e:8329"
 			host = "hosta-2.com"
-			responsible_person = "user2changed@softlaer.com"
+			responsible_person = "user2changed@softlayer.com"
 			ttl = 1000
 			type = "aaaa"
 		}
@@ -286,26 +286,25 @@ resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 var testAccCheckSoftLayerDnsDomainConfig_changed = fmt.Sprintf(`
 resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 	name = "%s"
-	serial = %d
 	records = [
 		{
 			data = "127.0.0.2"
 			host = "hosta.com"
-			responsible_person = "user@softlaer.com"
+			responsible_person = "user@softlayer.com"
 			ttl = 900
 			type = "a"
 		},
 		{
 			data = "fe80:0000:0000:0000:0202:b3ff:fe1e:8329"
 			host = "hosta-2.com"
-			responsible_person = "user2changed@softlaer.com"
+			responsible_person = "user2changed@softlayer.com"
 			ttl = 1000
 			type = "aaaa"
 		}
 	]
 }
-`, test_dns_domain_name, changed_serial)
+`, changed_dns_domain_name)
 
 var test_dns_domain_name = "zxczcxzxc.com"
-var changed_serial = 1234567890
+var changed_dns_domain_name = "vbnvnvbnv.com"
 var firstDnsId = 0

--- a/softlayer/resource_softlayer_dns_domain_test.go
+++ b/softlayer/resource_softlayer_dns_domain_test.go
@@ -23,30 +23,44 @@ func TestAccSoftLayerDnsDomain_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckSoftLayerDnsDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckSoftLayerDnsDomainConfig_basic,
+				Config: fmt.Sprintf(config, domainName1, target1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
 					testAccCheckSoftLayerDnsDomainAttributes(&dns_domain),
 					saveSoftLayerDnsDomainId(&dns_domain, &firstDnsId),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", test_dns_domain_name),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", domainName1),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain.acceptance_test_dns_domain-1", "target", target),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", "target", target1),
 				),
 				Destroy: false,
 			},
 			{
-				Config: testAccCheckSoftLayerDnsDomainConfig_changed,
+				Config: fmt.Sprintf(config, domainName2, target1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
 					testAccCheckSoftLayerDnsDomainAttributes(&dns_domain),
 					testAccCheckSoftLayerDnsDomainRecordDomainId(
 						"softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", changed_dns_domain_name),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", domainName2),
 					resource.TestCheckResourceAttr(
-						"softlayer_dns_domain.acceptance_test_dns_domain-1", "target", target),
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", "target", target1),
 					testAccCheckSoftLayerDnsDomainChanged(&dns_domain),
+				),
+				Destroy: false,
+			},
+			{
+				Config: fmt.Sprintf(config, domainName2, target2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSoftLayerDnsDomainExists("softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
+					testAccCheckSoftLayerDnsDomainAttributes(&dns_domain),
+					testAccCheckSoftLayerDnsDomainRecordDomainId(
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", &dns_domain),
+					resource.TestCheckResourceAttr(
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", "name", domainName2),
+					resource.TestCheckResourceAttr(
+						"softlayer_dns_domain.acceptance_test_dns_domain-1", "target", target2),
 				),
 				Destroy: false,
 			},
@@ -165,7 +179,9 @@ func testAccCheckSoftLayerDnsDomainExists(n string, dns_domain *datatypes.Dns_Do
 		dns_id, _ := strconv.Atoi(rs.Primary.ID)
 
 		service := services.GetDnsDomainService(testAccProvider.Meta().(*session.Session))
-		found_domain, err := service.Id(dns_id).GetObject()
+		found_domain, err := service.Id(dns_id).Mask(
+			"id,name,updateDate,resourceRecords",
+		).GetObject()
 
 		if err != nil {
 			return err
@@ -181,21 +197,29 @@ func testAccCheckSoftLayerDnsDomainExists(n string, dns_domain *datatypes.Dns_Do
 	}
 }
 
-var testAccCheckSoftLayerDnsDomainConfig_basic = fmt.Sprintf(`
+var config = `
 resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
 	name = "%s"
 	target = "%s"
 }
-`, test_dns_domain_name, target)
+`
 
-var testAccCheckSoftLayerDnsDomainConfig_changed = fmt.Sprintf(`
-resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
-	name = "%s"
-	target = "%s"
-}
-`, changed_dns_domain_name, target)
+//var testAccCheckSoftLayerDnsDomainConfig_basic = fmt.Sprintf(`
+//resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
+//	name = "%s"
+//	target = "%s"
+//}
+//`, test_dns_domain_name, target1)
+//
+//var testAccCheckSoftLayerDnsDomainConfig_changed = fmt.Sprintf(`
+//resource "softlayer_dns_domain" "acceptance_test_dns_domain-1" {
+//	name = "%s"
+//	target = "%s"
+//}
+//`, changed_dns_domain_name, target1)
 
-var test_dns_domain_name = "zxczcxzxc.com"
-var changed_dns_domain_name = "vbnvnvbnv.com"
-var target = "172.16.0.100"
+var domainName1 = "zxczcxzxc.com"
+var domainName2 = "vbnvnvbnv.com"
+var target1 = "172.16.0.100"
+var target2 = "172.16.0.101"
 var firstDnsId = 0


### PR DESCRIPTION
All dns tests pass now.

Decided to remove record management from the dns domain resource. Was getting too unmanageable with SoftLayer automatically creating the NS records for you under the covers. However, added a _faked_ attribute called "target" in which you specify the primary ip address that the domain will resolve to. This is similar to how it works in the portal. This enables the domain create to succeed, since it will include an A record with the target ip address. Updates to this target record are supported through the domain resource.

All other records can be created using the domain record resource. SRV record creation and editing was tested.

Other things were improved:
- Preventing users from managing NS records. These are automatically created by SoftLayer with correct values. Users should never have to manage these themselves. Trying to manage these result in conflicts with changes SoftLayer can do to the record properties
- Preventing users from using uppercase letters in IPv6 addresses. SoftLayer lowercases IPv6 addresses in the record's data without warning. This becomes unmanageable if the address in .TF uses uppercase letters (which is valid in IPv6) as Terraform will always see a change necessary after an apply. 
