### PR TITLE
Make virtual guest resource property names clearer

### DIFF
--- a/docs/softlayer_virtual_guest.md
+++ b/docs/softlayer_virtual_guest.md
@@ -7,9 +7,9 @@ Provides a `virtual_guest` resource. This allows virtual guests to be created, u
 resource "softlayer_virtual_guest" "twc_terraform_sample" {
     name = "twc-terraform-sample-name"
     domain = "bar.example.com"
-    image = "DEBIAN_7_64"
+    os_reference_code = "DEBIAN_7_64"
     datacenter = "wdc01"
-    public_network_speed = 10
+    network_speed = 10
     hourly_billing = true
     private_network_only = false
     cpu = 1
@@ -42,7 +42,7 @@ resource "softlayer_virtual_guest" "terraform-sample-BDTGroup" {
    cpu = 1
    ram = 1024
    local_disk = false
-   block_device_template_group_gid = "****-****-****-****-****"
+   image_id = "****-****-****-****-****"
 }
 ```
 
@@ -75,13 +75,13 @@ The following arguments are supported:
     * Specifies whether or not the instance must only run on hosts with instances from the same account
     * *Default*: nil
     * *Optional*
-* `image` | *string*
-    * An identifier for the operating system to provision the computing instance with.
-    * **Conditionally required**    - Disallowed when blockDeviceTemplateGroup.globalIdentifier is provided, as the template will specify the operating system.
-* `block_device_template_group_gid` | *string*
-    * A global identifier for the template to be used to provision the computing instance.
-    * **Conditionally required**    - Disallowed when operatingSystemReferenceCode is provided, as the template will specify the operating system.
-* `public_network_speed` | *int*
+* `os_reference_code` | *string*
+    * An operating system reference code that will be used to provision the computing instance.
+    * **Conflicts with** `image_id`.
+* `image_id` | *string*
+    * A global identifier for the image template to be used to provision the computing instance.
+    * **Conflicts with** `os_reference_code`.
+* `network_speed` | *int*
     * Specifies the connection speed for the instance's network components.
     * *Default*: 10
     * *Optional*

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -28,42 +28,43 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 		Importer: &schema.ResourceImporter{},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"domain": &schema.Schema{
+			"domain": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"image": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"os_reference_code": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"image_id"},
 			},
 
-			"hourly_billing": &schema.Schema{
+			"hourly_billing": {
 				Type:     schema.TypeBool,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"private_network_only": &schema.Schema{
+			"private_network_only": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 				ForceNew: true,
 			},
 
-			"datacenter": &schema.Schema{
+			"datacenter": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"cpu": &schema.Schema{
+			"cpu": {
 				Type:     schema.TypeInt,
 				Required: true,
 				// TODO: This fields for now requires recreation, because currently for some reason SoftLayer resets "dedicated_acct_host_only"
@@ -72,7 +73,7 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"ram": &schema.Schema{
+			"ram": {
 				Type:     schema.TypeInt,
 				Required: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
@@ -90,25 +91,25 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 				},
 			},
 
-			"dedicated_acct_host_only": &schema.Schema{
+			"dedicated_acct_host_only": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"front_end_vlan": &schema.Schema{
+			"front_end_vlan": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"vlan_number": &schema.Schema{
+						"vlan_number": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"primary_router_hostname": &schema.Schema{
+						"primary_router_hostname": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
@@ -116,26 +117,26 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 				},
 			},
 
-			"front_end_subnet": &schema.Schema{
+			"front_end_subnet": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
 
-			"back_end_vlan": &schema.Schema{
+			"back_end_vlan": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"vlan_number": &schema.Schema{
+						"vlan_number": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"primary_router_hostname": &schema.Schema{
+						"primary_router_hostname": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
@@ -143,73 +144,74 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 				},
 			},
 
-			"back_end_subnet": &schema.Schema{
+			"back_end_subnet": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
 
-			"disks": &schema.Schema{
+			"disks": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
 
-			"public_network_speed": &schema.Schema{
+			"network_speed": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  1000,
 			},
 
-			"ipv4_address": &schema.Schema{
+			"ipv4_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"ipv4_address_private": &schema.Schema{
+			"ipv4_address_private": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"ip_address_id": &schema.Schema{
+			"ip_address_id": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
-			"ip_address_id_private": &schema.Schema{
+			"ip_address_id_private": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
-			"ssh_keys": &schema.Schema{
+			"ssh_keys": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
 
-			"user_data": &schema.Schema{
+			"user_data": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"local_disk": &schema.Schema{
+			"local_disk": {
 				Type:     schema.TypeBool,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"post_install_script_uri": &schema.Schema{
+			"post_install_script_uri": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  nil,
 				ForceNew: true,
 			},
 
-			"block_device_template_group_gid": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"image_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"os_reference_code"},
 			},
 		},
 	}
@@ -253,7 +255,7 @@ func getVirtualGuestTemplateFromResourceData(d *schema.ResourceData, meta interf
 	}
 
 	networkComponent := datatypes.Virtual_Guest_Network_Component{
-		MaxSpeed: sl.Int(d.Get("public_network_speed").(int)),
+		MaxSpeed: sl.Int(d.Get("network_speed").(int)),
 	}
 
 	opts := datatypes.Virtual_Guest{
@@ -274,13 +276,13 @@ func getVirtualGuestTemplateFromResourceData(d *schema.ResourceData, meta interf
 		opts.DedicatedAccountHostOnlyFlag = sl.Bool(dedicatedAcctHostOnly.(bool))
 	}
 
-	if globalIdentifier, ok := d.GetOk("block_device_template_group_gid"); ok {
+	if globalIdentifier, ok := d.GetOk("image_id"); ok {
 		opts.BlockDeviceTemplateGroup = &datatypes.Virtual_Guest_Block_Device_Template_Group{
 			GlobalIdentifier: sl.String(globalIdentifier.(string)),
 		}
 	}
 
-	if operatingSystemReferenceCode, ok := d.GetOk("image"); ok {
+	if operatingSystemReferenceCode, ok := d.GetOk("os_reference_code"); ok {
 		opts.OperatingSystemReferenceCode = sl.String(operatingSystemReferenceCode.(string))
 	}
 
@@ -439,7 +441,7 @@ func resourceSoftLayerVirtualGuestRead(d *schema.ResourceData, meta interface{})
 		d.Set("datacenter", *result.Datacenter.Name)
 	}
 
-	d.Set("public_network_speed", *result.PrimaryNetworkComponent.MaxSpeed)
+	d.Set("network_speed", *result.PrimaryNetworkComponent.MaxSpeed)
 	d.Set("cpu", *result.StartCpus)
 	d.Set("ram", *result.MaxMemory)
 	d.Set("dedicated_acct_host_only", *result.DedicatedAccountHostOnlyFlag)
@@ -543,8 +545,8 @@ func resourceSoftLayerVirtualGuestUpdate(d *schema.ResourceData, meta interface{
 		upgradeOptions[product.MemoryCategoryCode] = float64(int(memoryInMB / 1024))
 	}
 
-	if d.HasChange("public_network_speed") {
-		upgradeOptions[product.NICSpeedCategoryCode] = float64(d.Get("public_network_speed").(int))
+	if d.HasChange("network_speed") {
+		upgradeOptions[product.NICSpeedCategoryCode] = float64(d.Get("network_speed").(int))
 	}
 
 	if len(upgradeOptions) > 0 {

--- a/softlayer/resource_softlayer_virtual_guest_test.go
+++ b/softlayer/resource_softlayer_virtual_guest_test.go
@@ -1,6 +1,7 @@
 package softlayer
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -21,7 +22,7 @@ func TestAccSoftLayerVirtualGuest_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSoftLayerVirtualGuestDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:  testAccCheckSoftLayerVirtualGuestConfig_basic,
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
@@ -33,7 +34,7 @@ func TestAccSoftLayerVirtualGuest_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_virtual_guest.terraform-acceptance-test-1", "datacenter", "ams01"),
 					resource.TestCheckResourceAttr(
-						"softlayer_virtual_guest.terraform-acceptance-test-1", "public_network_speed", "10"),
+						"softlayer_virtual_guest.terraform-acceptance-test-1", "network_speed", "10"),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtual_guest.terraform-acceptance-test-1", "hourly_billing", "true"),
 					resource.TestCheckResourceAttr(
@@ -62,7 +63,7 @@ func TestAccSoftLayerVirtualGuest_Basic(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config:  testAccCheckSoftLayerVirtualGuestConfig_userDataUpdate,
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
@@ -72,20 +73,20 @@ func TestAccSoftLayerVirtualGuest_Basic(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccCheckSoftLayerVirtualGuestConfig_upgradeMemoryNetworkSpeed,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerVirtualGuestExists("softlayer_virtual_guest.terraform-acceptance-test-1", &guest),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtual_guest.terraform-acceptance-test-1", "ram", "2048"),
 					resource.TestCheckResourceAttr(
-						"softlayer_virtual_guest.terraform-acceptance-test-1", "public_network_speed", "100"),
+						"softlayer_virtual_guest.terraform-acceptance-test-1", "network_speed", "100"),
 				),
 			},
 
 			// TODO: currently CPU upgrade test is disabled, due to unexpected behavior of field "dedicated_acct_host_only".
 			// TODO: For some reason it is reset by SoftLayer to "false". Daniel Bright reported corresponding issue to SoftLayer team.
-			//			resource.TestStep{
+			//			{
 			//				Config: testAccCheckSoftLayerVirtualGuestConfig_vmUpgradeCPUs,
 			//				Check: resource.ComposeTestCheckFunc(
 			//					testAccCheckSoftLayerVirtualGuestExists("softlayer_virtual_guest.terraform-acceptance-test-1", &guest),
@@ -106,10 +107,10 @@ func TestAccSoftLayerVirtualGuest_BlockDeviceTemplateGroup(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSoftLayerVirtualGuestDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckSoftLayerVirtualGuestConfig_blockDeviceTemplateGroup,
 				Check: resource.ComposeTestCheckFunc(
-					// block_device_template_group_gid value is hardcoded. If it's valid then virtual guest will be created well
+					// image_id value is hardcoded. If it's valid then virtual guest will be created well
 					testAccCheckSoftLayerVirtualGuestExists("softlayer_virtual_guest.terraform-acceptance-test-BDTGroup", &guest),
 				),
 			},
@@ -125,10 +126,10 @@ func TestAccSoftLayerVirtualGuest_postInstallScriptUri(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSoftLayerVirtualGuestDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckSoftLayerVirtualGuestConfig_postInstallScriptUri,
 				Check: resource.ComposeTestCheckFunc(
-					// block_device_template_group_gid value is hardcoded. If it's valid then virtual guest will be created well
+					// image_id value is hardcoded. If it's valid then virtual guest will be created well
 					testAccCheckSoftLayerVirtualGuestExists("softlayer_virtual_guest.terraform-acceptance-test-pISU", &guest),
 				),
 			},
@@ -169,7 +170,7 @@ func testAccCheckSoftLayerVirtualGuestExists(n string, guest *datatypes.Virtual_
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No virtual guest ID is set")
+			return errors.New("No virtual guest ID is set")
 		}
 
 		id, err := strconv.Atoi(rs.Primary.ID)
@@ -188,7 +189,7 @@ func testAccCheckSoftLayerVirtualGuestExists(n string, guest *datatypes.Virtual_
 		fmt.Printf("The ID is %d", id)
 
 		if *retrieveVirtGuest.Id != id {
-			return fmt.Errorf("Virtual guest not found")
+			return errors.New("Virtual guest not found")
 		}
 
 		*guest = retrieveVirtGuest
@@ -201,9 +202,9 @@ const testAccCheckSoftLayerVirtualGuestConfig_basic = `
 resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     name = "terraform-test"
     domain = "bar.example.com"
-    image = "DEBIAN_7_64"
+    os_reference_code = "DEBIAN_7_64"
     datacenter = "ams01"
-    public_network_speed = 10
+    network_speed = 10
     hourly_billing = true
 	private_network_only = false
     cpu = 1
@@ -219,9 +220,9 @@ const testAccCheckSoftLayerVirtualGuestConfig_userDataUpdate = `
 resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     name = "terraform-test"
     domain = "bar.example.com"
-    image = "DEBIAN_7_64"
+    os_reference_code = "DEBIAN_7_64"
     datacenter = "ams01"
-    public_network_speed = 10
+    network_speed = 10
     hourly_billing = true
     cpu = 1
     ram = 1024
@@ -236,9 +237,9 @@ const testAccCheckSoftLayerVirtualGuestConfig_upgradeMemoryNetworkSpeed = `
 resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     name = "terraform-test"
     domain = "bar.example.com"
-    image = "DEBIAN_7_64"
+    os_reference_code = "DEBIAN_7_64"
     datacenter = "ams01"
-    public_network_speed = 100
+    network_speed = 100
     hourly_billing = true
     cpu = 1
     ram = 2048
@@ -253,9 +254,9 @@ const testAccCheckSoftLayerVirtualGuestConfig_vmUpgradeCPUs = `
 resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     name = "terraform-test"
     domain = "bar.example.com"
-    image = "DEBIAN_7_64"
+    os_reference_code = "DEBIAN_7_64"
     datacenter = "ams01"
-    public_network_speed = 100
+    network_speed = 100
     hourly_billing = true
     cpu = 2
     ram = 2048
@@ -270,9 +271,9 @@ const testAccCheckSoftLayerVirtualGuestConfig_postInstallScriptUri = `
 resource "softlayer_virtual_guest" "terraform-acceptance-test-pISU" {
     name = "terraform-test-pISU"
     domain = "bar.example.com"
-    image = "DEBIAN_7_64"
+    os_reference_code = "DEBIAN_7_64"
     datacenter = "ams01"
-    public_network_speed = 10
+    network_speed = 10
     hourly_billing = true
 	private_network_only = false
     cpu = 1
@@ -290,11 +291,11 @@ resource "softlayer_virtual_guest" "terraform-acceptance-test-BDTGroup" {
     name = "terraform-test-blockDeviceTemplateGroup"
     domain = "bar.example.com"
     datacenter = "ams01"
-    public_network_speed = 10
+    network_speed = 10
     hourly_billing = false
     cpu = 1
     ram = 1024
     local_disk = false
-    block_device_template_group_gid = "ac2b413c-9893-4178-8e62-a24cbe2864db"
+    image_id = "ac2b413c-9893-4178-8e62-a24cbe2864db"
 }
 `


### PR DESCRIPTION
- Change image to os_reference_code
- Change block_device_template_group_gid to image_id
- Change public_network_speed to network_speed
- Tell terraform that image_id and os_reference_code conflict with each
  other.
- Fix other intellij/go warnings.
- Update tests (they pass)
- Update documentation.
