### PR TITLE
User Resource Enhancements

### DIFF
--- a/docs/resources/softlayer_user.md
+++ b/docs/resources/softlayer_user.md
@@ -26,8 +26,7 @@ resource "softlayer_user" "joe" {
         "RESET_PORTAL_PASSWORD"
     ]
     state        = "GA"
-    timezone     = 114
-    user_status  = 1001
+    timezone     = "EST"
     username     = "joedoe"
 }
 ```
@@ -88,15 +87,15 @@ The following arguments are supported:
 * `state` | *string*
     * User's street address state.
     * **Required**
-* `timezone` | *int*
-    * User's timezone id (no validation checks with the street address).
+* `timezone` | *string*
+    * User's timezone (shortname, e.g., "EST")
       Value is one of [SoftLayer_Locale_Timezone](http://sldn.softlayer.com/reference/datatypes/SoftLayer_Locale_Timezone).
     * **Required**
-* `user_status` | *int*
-    * Status id of user's login status. Value is one of
+* `user_status` | *string*
+    * User's login status. Value is one of
       [SoftLayer_User_Customer_Status](http://sldn.softlayer.com/reference/datatypes/SoftLayer_User_Customer_Status).
     * *Optional*
-    * *Default*: 1001 // means 'active'
+    * *Default*: "ACTIVE"
 * `username` | *string*
     * A name that uniquely identifies a user globally across all SoftLayer
       logins. It is also the login userid. Once a user login is created,

--- a/softlayer/resource_softlayer_user.go
+++ b/softlayer/resource_softlayer_user.go
@@ -313,7 +313,7 @@ func resourceSoftLayerUserUpdate(d *schema.ResourceData, meta interface{}) error
 
 	// Some fields cannot be updated such as username. Computed fields also cannot be updated
 	// by explicitly providing a value. So only update the fields that are editable.
-	// TODO: For now you may not update the password.
+	// Password changes can also not be fully automated, and are not supported
 	if d.HasChange("first_name") {
 		userObj.FirstName = sl.String(d.Get("first_name").(string))
 	}

--- a/softlayer/resource_softlayer_user.go
+++ b/softlayer/resource_softlayer_user.go
@@ -15,7 +15,7 @@ import (
 	"github.com/softlayer/softlayer-go/sl"
 )
 
-const userCustomerCancelStatus = "CANCEL_PENDING"
+const userCustomerCancelStatus = 1021
 
 func resourceSoftLayerUser() *schema.Resource {
 	return &schema.Resource{
@@ -434,17 +434,12 @@ func resourceSoftLayerUserDelete(d *schema.ResourceData, meta interface{}) error
 
 	id, _ := strconv.Atoi(d.Id())
 
-	userCancelStatusID, err := getUserStatusIDByName(sess, userCustomerCancelStatus)
-	if err != nil {
-		return err
-	}
-
 	user := datatypes.User_Customer{
-		UserStatusId: &userCancelStatusID,
+		UserStatusId: sl.Int(userCustomerCancelStatus),
 	}
 
 	log.Printf("[INFO] Deleting SoftLayer user: %d", id)
-	_, err = service.Id(id).EditObject(&user)
+	_, err := service.Id(id).EditObject(&user)
 	if err != nil {
 		return fmt.Errorf("Error deleting SoftLayer user: %s", err)
 	}

--- a/softlayer/resource_softlayer_user.go
+++ b/softlayer/resource_softlayer_user.go
@@ -362,17 +362,22 @@ func resourceSoftLayerUserUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("permissions") {
-		// TODO Use set math functions (in schema.Set) to compute the difference, vs clearing and re-adding permissions
 		old, new := d.GetChange("permissions")
 
-		oldPermissions := make([]datatypes.User_Customer_CustomerPermission_Permission, 0, old.(*schema.Set).Len())
-		newPermissions := make([]datatypes.User_Customer_CustomerPermission_Permission, 0, new.(*schema.Set).Len())
+		// 1. Remove old permissions no longer appearing in the new set
+		// 2. Add new permissions not already granted
 
-		for _, elem := range old.(*schema.Set).List() {
+		remove := old.(*schema.Set).Difference(new.(*schema.Set)).List()
+		add := new.(*schema.Set).Difference(old.(*schema.Set)).List()
+
+		oldPermissions := make([]datatypes.User_Customer_CustomerPermission_Permission, 0, len(remove))
+		newPermissions := make([]datatypes.User_Customer_CustomerPermission_Permission, 0, len(add))
+
+		for _, elem := range remove {
 			oldPermissions = append(oldPermissions, makePermission(elem.(string)))
 		}
 
-		for _, elem := range new.(*schema.Set).List() {
+		for _, elem := range add {
 			newPermissions = append(newPermissions, makePermission(elem.(string)))
 		}
 

--- a/softlayer/resource_softlayer_user_test.go
+++ b/softlayer/resource_softlayer_user_test.go
@@ -114,10 +114,10 @@ func testAccCheckSoftLayerUserDestroy(s *terraform.State) error {
 		userID, _ := strconv.Atoi(rs.Primary.ID)
 
 		// Try to find the user
-		user, err := client.Id(userID).Mask("userStatus[keyName]").GetObject()
+		user, err := client.Id(userID).Mask("userStatusId").GetObject()
 
 		// Users are not immediately deleted, but rather placed into a 'cancel_pending' (1021) status
-		if err != nil || *user.UserStatus.KeyName != userCustomerCancelStatus {
+		if err != nil || *user.UserStatusId != userCustomerCancelStatus {
 			return fmt.Errorf("SoftLayer User still exists")
 		}
 	}

--- a/softlayer/resource_softlayer_user_test.go
+++ b/softlayer/resource_softlayer_user_test.go
@@ -48,9 +48,9 @@ func TestAccSoftLayerUser_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_user.testuser", "country", "US"),
 					resource.TestCheckResourceAttr(
-						"softlayer_user.testuser", "timezone", "114"),
+						"softlayer_user.testuser", "timezone", "EST"),
 					resource.TestCheckResourceAttr(
-						"softlayer_user.testuser", "user_status", "1001"),
+						"softlayer_user.testuser", "user_status", "ACTIVE"),
 					resource.TestCheckResourceAttr(
 						"softlayer_user.testuser", "password", hash(testAccUserPassword)),
 					resource.TestCheckResourceAttr(
@@ -86,9 +86,9 @@ func TestAccSoftLayerUser_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_user.testuser", "country", "CA"),
 					resource.TestCheckResourceAttr(
-						"softlayer_user.testuser", "timezone", "117"),
+						"softlayer_user.testuser", "timezone", "MST"),
 					resource.TestCheckResourceAttr(
-						"softlayer_user.testuser", "user_status", "1002"),
+						"softlayer_user.testuser", "user_status", "INACTIVE"),
 					resource.TestCheckResourceAttr(
 						"softlayer_user.testuser", "password", hash(testAccUserPassword)),
 					resource.TestCheckResourceAttr(
@@ -114,10 +114,10 @@ func testAccCheckSoftLayerUserDestroy(s *terraform.State) error {
 		userID, _ := strconv.Atoi(rs.Primary.ID)
 
 		// Try to find the user
-		user, err := client.Id(userID).GetObject()
+		user, err := client.Id(userID).Mask("userStatus[keyName]").GetObject()
 
 		// Users are not immediately deleted, but rather placed into a 'cancel_pending' (1021) status
-		if err != nil || *user.UserStatusId != 1021 {
+		if err != nil || *user.UserStatus.KeyName != userCustomerCancelStatus {
 			return fmt.Errorf("SoftLayer User still exists")
 		}
 	}
@@ -168,7 +168,7 @@ resource "softlayer_user" "testuser" {
     city = "Atlanta"
     state = "GA"
     country = "US"
-    timezone = 114
+    timezone = "EST"
     password = "%s"
     permissions = [
         "SERVER_ADD",
@@ -189,8 +189,8 @@ resource "softlayer_user" "testuser" {
     city = "Montreal"
     state = "QC"
     country = "CA"
-    timezone = 117
-    user_status = 1002
+    timezone = "MST"
+    user_status = "INACTIVE"
     password = "%s"
     permissions = [
         "SERVER_ADD",


### PR DESCRIPTION
- Schema fields "timezone" and "user_status" now accept string values instead of integer-based IDs.
- Logic to handle permission changes uses set math to determine exactly which permissions to add/remove, versus just wiping all permissions and bulk loading the new set.
- Removed a TODO related to password update.  There is no current plan to support updating a user's password via Terraform, as the process cannot be fully automated.
