### PR TITLE
Local Load Balancer Service fixes

### DIFF
--- a/softlayer/resource_softlayer_lb_local_service.go
+++ b/softlayer/resource_softlayer_lb_local_service.go
@@ -132,8 +132,8 @@ func resourceSoftLayerLbLocalServiceCreate(d *schema.ResourceData, meta interfac
 		Id(sgID).
 		Mask("mask[id,port,ipAddressId]").
 		Filter(filter.New(
-			filter.Path("port").Eq(d.Get("port")),
-			filter.Path("ipAddressId").Eq(d.Get("ip_address_id"))).Build()).
+			filter.Path("services.port").Eq(d.Get("port")),
+			filter.Path("services.ipAddressId").Eq(d.Get("ip_address_id"))).Build()).
 		GetServices()
 
 	if err != nil || len(svcs) == 0 {

--- a/softlayer/resource_softlayer_lb_local_service.go
+++ b/softlayer/resource_softlayer_lb_local_service.go
@@ -1,11 +1,12 @@
 package softlayer
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/softlayer/softlayer-go/datatypes"
 	"github.com/softlayer/softlayer-go/filter"
@@ -115,16 +116,35 @@ func resourceSoftLayerLbLocalServiceCreate(d *schema.ResourceData, meta interfac
 
 	log.Println("[INFO] Creating load balancer service")
 
-	success, err := services.GetNetworkApplicationDeliveryControllerLoadBalancerVirtualIpAddressService(sess).
-		Id(vipID).
-		EditObject(&vip)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"pending"},
+		Target:  []string{"complete"},
+		Refresh: func() (interface{}, string, error) {
+			_, err := services.GetNetworkApplicationDeliveryControllerLoadBalancerVirtualIpAddressService(sess).
+				Id(vipID).
+				EditObject(&vip)
+
+			if apiErr, ok := err.(sl.Error); ok {
+				// 500 could mean that the LB is busy with another transaction. Retry
+				if apiErr.StatusCode == 500 {
+					return false, "pending", nil
+				}
+
+				// Any other error is unexpected. Abort
+				return false, "", err
+			}
+
+			return true, "complete", nil
+		},
+		Timeout:    10 * time.Minute,
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
 
 	if err != nil {
 		return fmt.Errorf("Error creating load balancer service: %s", err)
-	}
-
-	if !success {
-		return errors.New("Error creating load balancer service")
 	}
 
 	// Retrieve the newly created object, to obtain its ID
@@ -208,16 +228,35 @@ func resourceSoftLayerLbLocalServiceUpdate(d *schema.ResourceData, meta interfac
 
 	log.Println("[INFO] Updating load balancer service")
 
-	success, err := services.GetNetworkApplicationDeliveryControllerLoadBalancerVirtualIpAddressService(sess).
-		Id(vipID).
-		EditObject(&vip)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"pending"},
+		Target:  []string{"complete"},
+		Refresh: func() (interface{}, string, error) {
+			_, err := services.GetNetworkApplicationDeliveryControllerLoadBalancerVirtualIpAddressService(sess).
+				Id(vipID).
+				EditObject(&vip)
+
+			if apiErr, ok := err.(sl.Error); ok {
+				// 500 could mean that the LB is busy with another transaction. Retry
+				if apiErr.StatusCode == 500 {
+					return false, "pending", nil
+				}
+
+				// Any other error is unexpected. Abort
+				return false, "", err
+			}
+
+			return true, "complete", nil
+		},
+		Timeout:    10 * time.Minute,
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
 
 	if err != nil {
 		return fmt.Errorf("Error updating load balancer service: %s", err)
-	}
-
-	if !success {
-		return errors.New("Error updating load balancer service")
 	}
 
 	return resourceSoftLayerLbLocalServiceRead(d, meta)
@@ -250,9 +289,36 @@ func resourceSoftLayerLbLocalServiceDelete(d *schema.ResourceData, meta interfac
 
 	svcID, _ := strconv.Atoi(d.Id())
 
-	err := services.GetNetworkApplicationDeliveryControllerLoadBalancerServiceService(sess).
-		Id(svcID).
-		DeleteObject()
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"pending"},
+		Target:  []string{"complete"},
+		Refresh: func() (interface{}, string, error) {
+			err := services.GetNetworkApplicationDeliveryControllerLoadBalancerServiceService(sess).
+				Id(svcID).
+				DeleteObject()
+
+			if apiErr, ok := err.(sl.Error); ok {
+				switch {
+				case apiErr.StatusCode == 500 && apiErr.Exception == "SoftLayer_Exception_Network_Timeout":
+					// 500/Network_Timeout could mean that the LB is busy with another transaction. Retry
+					return false, "pending", nil
+				case apiErr.StatusCode == 404:
+					// 404 - service was deleted on the previous attempt
+					return true, "complete", nil
+				default:
+					// Any other error is unexpected. Abort
+					return false, "error", err
+				}
+			}
+
+			return true, "complete", nil
+		},
+		Timeout:    10 * time.Minute,
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
 
 	if err != nil {
 		return fmt.Errorf("Error deleting service: %s", err)

--- a/softlayer/resource_softlayer_lb_local_service.go
+++ b/softlayer/resource_softlayer_lb_local_service.go
@@ -269,7 +269,7 @@ func resourceSoftLayerLbLocalServiceRead(d *schema.ResourceData, meta interface{
 
 	svc, err := services.GetNetworkApplicationDeliveryControllerLoadBalancerServiceService(sess).
 		Id(svcID).
-		Mask("ipAddressId,port,healthChecks[type[keyname]],groupReferences[weight]").
+		Mask("ipAddressId,enabled,port,healthChecks[type[keyname]],groupReferences[weight]").
 		GetObject()
 
 	if err != nil {
@@ -280,6 +280,7 @@ func resourceSoftLayerLbLocalServiceRead(d *schema.ResourceData, meta interface{
 	d.Set("port", *svc.Port)
 	d.Set("health_check_type", *svc.HealthChecks[0].Type.Keyname)
 	d.Set("weight", *svc.GroupReferences[0].Weight)
+	d.Set("enabled", (*svc.Enabled == 1))
 
 	return nil
 }

--- a/softlayer/resource_softlayer_lb_local_service_test.go
+++ b/softlayer/resource_softlayer_lb_local_service_test.go
@@ -31,9 +31,9 @@ const testAccCheckSoftLayerLbLocalServiceConfig_basic = `
 resource "softlayer_virtual_guest" "test_server_1" {
     name = "terraform-test"
     domain = "bar.example.com"
-    image = "DEBIAN_7_64"
+    os_reference_code = "DEBIAN_7_64"
     datacenter = "tok02"
-    public_network_speed = 10
+    network_speed = 10
     hourly_billing = true
     private_network_only = false
     cpu = 1
@@ -45,9 +45,10 @@ resource "softlayer_virtual_guest" "test_server_1" {
 }
 
 resource "softlayer_lb_local" "testacc_foobar_lb" {
-    connections = 15000
+    connections = 250
     datacenter    = "tok02"
     ha_enabled  = false
+    dedicated = false
 }
 
 resource "softlayer_lb_local_service_group" "test_service_group" {


### PR DESCRIPTION
- Fixed a bad filter which was being ignored, causing all service objects to be returned instead of just the matching one, in turn causing multiple services to be assigned the same ID
- Added WaitForState() logic around create/update/delete calls, to prevent timeouts leading to unrecoverable state inconsistencies
- Sync "enabled" flag during refresh

Addresses #19 
