### PR TITLE
Fix VPX REST status checking logic for VPX 10.5.

### DIFF
--- a/softlayer/resource_softlayer_lb_vpx.go
+++ b/softlayer/resource_softlayer_lb_vpx.go
@@ -424,7 +424,7 @@ func resourceSoftLayerLbVpxCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Failed to create VIPs for Netscaler VPX ID: %d", id)
 	}
 
-	// Wait VPX service initializing. GetLoadBalancers() internally calls REST API of VPX and returns
+	// Wait while VPX service is initializing. GetLoadBalancers() internally calls REST API of VPX and returns
 	// an error "Could not connect to host" if the REST API is not available.
 	IsRESTReady := false
 


### PR DESCRIPTION
When a new netscaler VPX is created, it requires additional time for service initializing. The nitro API service status can be checked with NADCService.GetLoadBalancers() function as follows:

1) netscaler VPX 10.1
- When the nitro API service is not initialized : NADCService.GetLoadBalancers() returns an error :`{"error":"Could not connect to host","code":"HTTP"}` 
- When the nitro API service completes the initialization : NADCService.GetLoadBalancers() returns `nil`

2) netscaler VPX 10.5
- When the nitro API service is not initialized : NADCService.GetLoadBalancers() returns an error :`{"error":"Could not connect to host","code":"HTTP"}` 
- When the nitro API service completes the initialization : NADCService.GetLoadBalancers() returns `{"error":"There was a problem processing the reply from the application tier.  Please contact development.","code":"SoftLayer_Exception_Public"}`
