### PR TITLE
Change network speed reference for network_speed in virtual_guest

### DIFF
--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -577,7 +577,7 @@ func resourceSoftLayerVirtualGuestRead(d *schema.ResourceData, meta interface{})
 		"network_speed",
 		sl.Grab(
 			result,
-			"PrimaryNetworkComponent.MaxSpeed",
+			"PrimaryBackendNetworkComponent.MaxSpeed",
 			d.Get("network_speed").(int),
 		),
 	)


### PR DESCRIPTION
If a virtual guest only has private network interface, PrimaryNetworkComponent.MaxSpeed returns 0.
To support network_speed for the virtual guest with private network only, I changed network
 speed reference from PrimaryNetworkComponent.MaxSpeed to PrimaryBackendNetworkComponent.MaxSpeed.

This PR resolves the issue #58  