### PR TITLE
Support virtual guests with public IPv6 addresses

### DIFF
--- a/docs/resources/softlayer_virtual_guest.md
+++ b/docs/resources/softlayer_virtual_guest.md
@@ -139,7 +139,7 @@ The following attributes are exported:
 * `ipv4_address_private` - Private IPv4 address of the virtual guest.
 * `ip_address_id` - Unique ID for the public IPv4 address assigned to the virtual_guest.
 * `ipv6_address` - Public IPv6 address of the virtual guest. It is provided when `ipv6_enabled` is `true`.
-* `ip_address_id6` - Unique ID for the public IPv6 address assigned to the virtual_guest. It is provided when `ipv6_enabled` is `true`.
-* `public_subnet6` - Public IPv6 subnet. It is provided when `ipv6_enabled` is `true`.
+* `ipv6_address_id` - Unique ID for the public IPv6 address assigned to the virtual_guest. It is provided when `ipv6_enabled` is `true`.
+* `public_ipv6_subnet` - Public IPv6 subnet. It is provided when `ipv6_enabled` is `true`.
 
 

--- a/docs/resources/softlayer_virtual_guest.md
+++ b/docs/resources/softlayer_virtual_guest.md
@@ -124,6 +124,10 @@ The following arguments are supported:
 *   `tags` | *array* of strings
     * Set tags on this virtual guest. The characters permitted are A-Z, 0-9, whitespace, _ (underscore), - (hyphen), . (period), and : (colon). All other characters will be stripped away.
     * *Optional*
+*   `ipv6_enabled` | *boolean*
+    * Provides a primary public IPv6 address.
+    * *Optional*
+    * *Default*: false
 
 ## Attributes Reference
 
@@ -131,6 +135,11 @@ The following attributes are exported:
 
 * `id` - id of the virtual guest.
 * `ipv4_address` - Public IPv4 address of the virtual guest.
-* `ip_address_id_private` - Unique ID for the private ID address assigned to the virtual_guest.
+* `ip_address_id_private` - Unique ID for the private IPv4 address assigned to the virtual_guest.
 * `ipv4_address_private` - Private IPv4 address of the virtual guest.
-* `ip_address_id` - Unique ID for the public ID address assigned to the virtual_guest.
+* `ip_address_id` - Unique ID for the public IPv4 address assigned to the virtual_guest.
+* `ipv6_address` - Public IPv6 address of the virtual guest. It is provided when `ipv6_enabled` is `true`.
+* `ip_address_id6` - Unique ID for the public IPv6 address assigned to the virtual_guest. It is provided when `ipv6_enabled` is `true`.
+* `public_subnet6` - Public IPv6 subnet. It is provided when `ipv6_enabled` is `true`.
+
+

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -532,7 +532,13 @@ func resourceSoftLayerVirtualGuestCreate(d *schema.ResourceData, meta interface{
 	}
 
 	// Add an IPv6 price item
+	privateNetworkOnly := d.Get("private_network_only").(bool)
+
 	if d.Get("ipv6_enabled").(bool) {
+		if privateNetworkOnly {
+			return fmt.Errorf("Unable to configure a public IPv6 address with a private_network_only option.")
+		}
+
 		ipv6Items, err := services.GetProductPackageService(sess).
 			Id(*template.PackageId).
 			Mask("id,capacity,description,units,keyName,prices[id,categories[id,name,categoryCode]]").
@@ -584,7 +590,6 @@ func resourceSoftLayerVirtualGuestCreate(d *schema.ResourceData, meta interface{
 			"Error waiting for virtual machine (%s) to become ready: %s", d.Id(), err)
 	}
 
-	privateNetworkOnly := d.Get("private_network_only").(bool)
 	_, err = WaitForIPAvailable(d, meta, privateNetworkOnly)
 	if err != nil {
 		return fmt.Errorf(

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -264,7 +264,7 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 			},
 
 			// SoftLayer doesnot support public_subnet6 configuration in vm creation. So, public_subnet6
-			// is defined as a computed parameter.  
+			// is defined as a computed parameter.
 			"public_subnet6": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -263,10 +263,10 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 				Computed: true,
 			},
 
+			// SoftLayer doesnot support public_subnet6 configuration in vm creation. So, public_subnet6
+			// is defined as a computed parameter.  
 			"public_subnet6": {
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 
@@ -417,7 +417,6 @@ func getVirtualGuestTemplateFromResourceData(d *schema.ResourceData, meta interf
 
 	publicVlanId := d.Get("public_vlan_id").(int)
 	publicSubnet := d.Get("public_subnet").(string)
-	publicSubnet6 := d.Get("public_subnet6").(string)
 	privateVlanId := d.Get("private_vlan_id").(int)
 	privateSubnet := d.Get("private_subnet").(string)
 
@@ -438,18 +437,7 @@ func getVirtualGuestTemplateFromResourceData(d *schema.ResourceData, meta interf
 		primaryNetworkComponent.NetworkVlan.PrimarySubnetId = &primarySubnetId
 	}
 
-	// Apply frontend subnet6 if provided
-	if publicSubnet6 != "" {
-		primarySubnetId6, err := getSubnetId(publicSubnet6, meta)
-		if err != nil {
-			return opts, fmt.Errorf("Error creating virtual guest: %s", err)
-		}
-		primaryNetworkComponent.NetworkVlan.PrimarySubnetVersion6 = &datatypes.Network_Subnet{
-			Id: &primarySubnetId6,
-		}
-	}
-
-	if publicVlanId > 0 || publicSubnet != "" || publicSubnet6 != "" {
+	if publicVlanId > 0 || publicSubnet != "" {
 		opts.PrimaryNetworkComponent = &primaryNetworkComponent
 	}
 

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -258,14 +258,14 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 				Computed: true,
 			},
 
-			"ip_address_id6": {
+			"ipv6_address_id": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
-			// SoftLayer does not support public_subnet6 configuration in vm creation. So, public_subnet6
+			// SoftLayer does not support public_ipv6_subnet configuration in vm creation. So, public_ipv6_subnet
 			// is defined as a computed parameter.
-			"public_subnet6": {
+			"public_ipv6_subnet": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -680,10 +680,10 @@ func resourceSoftLayerVirtualGuestRead(d *schema.ResourceData, meta interface{})
 	if result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord != nil {
 		d.Set("ipv6_enabled", true)
 		d.Set("ipv6_address", *result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.IpAddress)
-		d.Set("ip_address_id6", *result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.GuestNetworkComponentBinding.IpAddressId)
+		d.Set("ipv6_address_id", *result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.GuestNetworkComponentBinding.IpAddressId)
 		publicSubnet := result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.Subnet
 		d.Set(
-			"public_subnet6",
+			"public_ipv6_subnet",
 			fmt.Sprintf("%s/%d", *publicSubnet.NetworkIdentifier, *publicSubnet.Cidr),
 		)
 	}

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -417,6 +417,7 @@ func getVirtualGuestTemplateFromResourceData(d *schema.ResourceData, meta interf
 
 	publicVlanId := d.Get("public_vlan_id").(int)
 	publicSubnet := d.Get("public_subnet").(string)
+	publicSubnet6 := d.Get("public_subnet6").(string)
 	privateVlanId := d.Get("private_vlan_id").(int)
 	privateSubnet := d.Get("private_subnet").(string)
 
@@ -437,7 +438,18 @@ func getVirtualGuestTemplateFromResourceData(d *schema.ResourceData, meta interf
 		primaryNetworkComponent.NetworkVlan.PrimarySubnetId = &primarySubnetId
 	}
 
-	if publicVlanId > 0 || publicSubnet != "" {
+	// Apply frontend subnet6 if provided
+	if publicSubnet6 != "" {
+		primarySubnetId6, err := getSubnetId(publicSubnet6, meta)
+		if err != nil {
+			return opts, fmt.Errorf("Error creating virtual guest: %s", err)
+		}
+		primaryNetworkComponent.NetworkVlan.PrimarySubnetVersion6 = &datatypes.Network_Subnet{
+			Id: &primarySubnetId6,
+		}
+	}
+
+	if publicVlanId > 0 || publicSubnet != "" || publicSubnet6 != "" {
 		opts.PrimaryNetworkComponent = &primaryNetworkComponent
 	}
 

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -672,6 +672,7 @@ func resourceSoftLayerVirtualGuestRead(d *schema.ResourceData, meta interface{})
 	)
 
 	if result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord != nil {
+		d.Set("ipv6_enabled", true)
 		d.Set("ipv6_address", *result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.IpAddress)
 		d.Set("ip_address_id6", *result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.GuestNetworkComponentBinding.IpAddressId)
 		publicSubnet := result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.Subnet
@@ -679,6 +680,8 @@ func resourceSoftLayerVirtualGuestRead(d *schema.ResourceData, meta interface{})
 			"public_subnet6",
 			fmt.Sprintf("%s/%d", *publicSubnet.NetworkIdentifier, *publicSubnet.Cidr),
 		)
+	} else {
+		d.Set("ipv6_enabled", false)
 	}
 
 	userData := result.UserData
@@ -686,7 +689,7 @@ func resourceSoftLayerVirtualGuestRead(d *schema.ResourceData, meta interface{})
 		data, err := base64.StdEncoding.DecodeString(*userData[0].Value)
 		if err != nil {
 			log.Printf("Can't base64 decode user data %s. error: %s", *userData[0].Value, err)
-			d.Set("user_metadata", userData)
+			d.Set("user_metadata", *userData[0].Value)
 		} else {
 			d.Set("user_metadata", string(data))
 		}

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -263,7 +263,7 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 				Computed: true,
 			},
 
-			// SoftLayer doesnot support public_subnet6 configuration in vm creation. So, public_subnet6
+			// SoftLayer does not support public_subnet6 configuration in vm creation. So, public_subnet6
 			// is defined as a computed parameter.
 			"public_subnet6": {
 				Type:     schema.TypeString,
@@ -676,6 +676,7 @@ func resourceSoftLayerVirtualGuestRead(d *schema.ResourceData, meta interface{})
 		fmt.Sprintf("%s/%d", *privateSubnet.NetworkIdentifier, *privateSubnet.Cidr),
 	)
 
+	d.Set("ipv6_enabled", false)
 	if result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord != nil {
 		d.Set("ipv6_enabled", true)
 		d.Set("ipv6_address", *result.PrimaryNetworkComponent.PrimaryVersion6IpAddressRecord.IpAddress)
@@ -685,8 +686,6 @@ func resourceSoftLayerVirtualGuestRead(d *schema.ResourceData, meta interface{})
 			"public_subnet6",
 			fmt.Sprintf("%s/%d", *publicSubnet.NetworkIdentifier, *publicSubnet.Cidr),
 		)
-	} else {
-		d.Set("ipv6_enabled", false)
 	}
 
 	userData := result.UserData

--- a/softlayer/resource_softlayer_virtual_guest_test.go
+++ b/softlayer/resource_softlayer_virtual_guest_test.go
@@ -63,9 +63,9 @@ func TestAccSoftLayerVirtualGuest_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"softlayer_virtual_guest.terraform-acceptance-test-1", "ipv6_address"),
 					resource.TestCheckResourceAttrSet(
-						"softlayer_virtual_guest.terraform-acceptance-test-1", "ip_address_id6"),
+						"softlayer_virtual_guest.terraform-acceptance-test-1", "ipv6_address_id"),
 					resource.TestCheckResourceAttrSet(
-						"softlayer_virtual_guest.terraform-acceptance-test-1", "public_subnet6"),
+						"softlayer_virtual_guest.terraform-acceptance-test-1", "public_ipv6_subnet"),
 				),
 			},
 

--- a/softlayer/resource_softlayer_virtual_guest_test.go
+++ b/softlayer/resource_softlayer_virtual_guest_test.go
@@ -31,7 +31,7 @@ func TestAccSoftLayerVirtualGuest_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_virtual_guest.terraform-acceptance-test-1", "domain", "bar.example.com"),
 					resource.TestCheckResourceAttr(
-						"softlayer_virtual_guest.terraform-acceptance-test-1", "datacenter", "wdc01"),
+						"softlayer_virtual_guest.terraform-acceptance-test-1", "datacenter", "wdc04"),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtual_guest.terraform-acceptance-test-1", "network_speed", "10"),
 					resource.TestCheckResourceAttr(
@@ -58,6 +58,14 @@ func TestAccSoftLayerVirtualGuest_Basic(t *testing.T) {
 						"softlayer_virtual_guest.terraform-acceptance-test-1",
 						"tags", []string{"collectd"},
 					),
+					resource.TestCheckResourceAttrSet(
+						"softlayer_virtual_guest.terraform-acceptance-test-1", "ipv6_enabled"),
+					resource.TestCheckResourceAttrSet(
+						"softlayer_virtual_guest.terraform-acceptance-test-1", "ipv6_address"),
+					resource.TestCheckResourceAttrSet(
+						"softlayer_virtual_guest.terraform-acceptance-test-1", "ip_address_id6"),
+					resource.TestCheckResourceAttrSet(
+						"softlayer_virtual_guest.terraform-acceptance-test-1", "public_subnet6"),
 				),
 			},
 
@@ -266,7 +274,7 @@ resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     hostname = "terraform-test"
     domain = "bar.example.com"
     os_reference_code = "DEBIAN_7_64"
-    datacenter = "wdc01"
+    datacenter = "wdc04"
     network_speed = 10
     hourly_billing = true
 	private_network_only = false
@@ -277,6 +285,7 @@ resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     tags = ["collectd"]
     dedicated_acct_host_only = true
     local_disk = false
+    ipv6_enabled = true
 }
 `
 
@@ -285,7 +294,7 @@ resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     hostname = "terraform-test"
     domain = "bar.example.com"
     os_reference_code = "DEBIAN_7_64"
-    datacenter = "wdc01"
+    datacenter = "wdc04"
     network_speed = 10
     hourly_billing = true
     cores = 1
@@ -295,6 +304,7 @@ resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     tags = ["mesos-master"]
     dedicated_acct_host_only = true
     local_disk = false
+    ipv6_enabled = true
 }
 `
 
@@ -303,7 +313,7 @@ resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     hostname = "terraform-test"
     domain = "bar.example.com"
     os_reference_code = "DEBIAN_7_64"
-    datacenter = "wdc01"
+    datacenter = "wdc04"
     network_speed = 100
     hourly_billing = true
     cores = 1
@@ -313,6 +323,7 @@ resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     tags = ["mesos-master"]
     dedicated_acct_host_only = true
     local_disk = false
+    ipv6_enabled = true
 }
 `
 
@@ -321,7 +332,7 @@ resource "softlayer_virtual_guest" "terraform-acceptance-test-1" {
     hostname = "terraform-test"
     domain = "bar.example.com"
     os_reference_code = "DEBIAN_7_64"
-    datacenter = "wdc01"
+    datacenter = "wdc04"
     network_speed = 100
     hourly_billing = true
     cores = 2
@@ -339,7 +350,7 @@ resource "softlayer_virtual_guest" "terraform-acceptance-test-pISU" {
     hostname = "terraform-test-pISU"
     domain = "bar.example.com"
     os_reference_code = "DEBIAN_7_64"
-    datacenter = "wdc01"
+    datacenter = "wdc04"
     network_speed = 10
     hourly_billing = true
 	private_network_only = false
@@ -357,7 +368,7 @@ const testAccCheckSoftLayerVirtualGuestConfig_blockDeviceTemplateGroup = `
 resource "softlayer_virtual_guest" "terraform-acceptance-test-BDTGroup" {
     hostname = "terraform-test-blockDeviceTemplateGroup"
     domain = "bar.example.com"
-    datacenter = "wdc01"
+    datacenter = "wdc04"
     network_speed = 10
     hourly_billing = false
     cores = 1
@@ -371,7 +382,7 @@ const testAccCheckSoftLayerVirtualGuestConfig_customImageMultipleDisks = `
 resource "softlayer_virtual_guest" "terraform-acceptance-test-disks" {
     hostname = "terraform-test-blockDeviceTemplateGroup"
     domain = "bar.example.com"
-    datacenter = "wdc01"
+    datacenter = "wdc04"
     network_speed = 10
     hourly_billing = false
     cores = 1


### PR DESCRIPTION
Add IPv6 features to a virtual guest resource and fix minor bugs as follows: 
- Add ipv6_enabled, ipv6_address, ip_address_id6, and public_subnet6 to a virtual_guest schema.
- Remove createObject call and use PlaceOrder for virtual_guest creation.
- Fix user_metadata setting bug.

This PR provides function for #15.