### PR TITLE
Making targetIP an optional parameter

### DIFF
--- a/docs/resources/softlayer_dns_domain.md
+++ b/docs/resources/softlayer_dns_domain.md
@@ -14,7 +14,7 @@ resource "softlayer_dns_domain" "dns-domain-test" {
 The following arguments are supported:
 
 * `name` | *string* - (Required) A domain's name including top-level domain, for example "example.com". When the domain is created, proper `NS` and `SOA`  records are created automatically for it.
-* `target`|*string* - (Required) The primary target IP address that the domain will resolve to. Upon creation, an `A` record will be created with a host value of `@` and a data-target value of the IP address provided which will be associated to the new domain.
+* `target`|*string* - (Optional) The primary target IP address that the domain will resolve to. Upon creation, an `A` record will be created with a host value of `@` and a data-target value of the IP address provided which will be associated to the new domain.
 
 ## Attributes Reference
 

--- a/softlayer/resource_softlayer_dns_domain.go
+++ b/softlayer/resource_softlayer_dns_domain.go
@@ -44,7 +44,7 @@ func resourceSoftLayerDnsDomain() *schema.Resource {
 
 			"target": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 		},
 	}
@@ -59,14 +59,17 @@ func resourceSoftLayerDnsDomainCreate(d *schema.ResourceData, meta interface{}) 
 		Name: sl.String(d.Get("name").(string)),
 	}
 
-	// Create dns domain zone with default A record based on the target value
-	opts.ResourceRecords = []datatypes.Dns_Domain_ResourceRecord{
-		{
-			Data: sl.String(d.Get("target").(string)),
-			Host: sl.String("@"),
-			Ttl:  sl.Int(86400),
-			Type: sl.String("a"),
-		},
+	if targetString := sl.String(d.Get("target").(string)); *targetString != "" {
+		opts.ResourceRecords = []datatypes.Dns_Domain_ResourceRecord{
+			{
+				Data: sl.String(d.Get("target").(string)),
+				Host: sl.String("@"),
+				Ttl:  sl.Int(86400),
+				Type: sl.String("a"),
+			},
+		}
+	} else {
+		opts.ResourceRecords = []datatypes.Dns_Domain_ResourceRecord{}
 	}
 
 	// create Dns_Domain object

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/dns.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/dns.go
@@ -40,7 +40,7 @@ type Dns_Domain struct {
 	ResourceRecordCount *uint `json:"resourceRecordCount,omitempty" xmlrpc:"resourceRecordCount,omitempty"`
 
 	// The individual records contained within a domain record. These include but are not limited to A, AAAA, MX, CTYPE, SPF and TXT records.
-	ResourceRecords []Dns_Domain_ResourceRecord `json:"resourceRecords,omitempty" xmlrpc:"resourceRecords,omitempty"`
+	ResourceRecords []Dns_Domain_ResourceRecord `json:"resourceRecords" xmlrpc:"resourceRecords"`
 
 	// The secondary DNS record that defines this domain as being managed through zone transfers.
 	Secondary *Dns_Secondary `json:"secondary,omitempty" xmlrpc:"secondary,omitempty"`


### PR DESCRIPTION
- Initialized `ResourceRecords` with an empty struct when target is not given
- Updated readme