### PR TITLE
Fix lb multiple service groups

### DIFF
--- a/softlayer/resource_softlayer_lb_local_service.go
+++ b/softlayer/resource_softlayer_lb_local_service.go
@@ -327,7 +327,7 @@ func updateLoadBalancerService(sess *session.Session, vipID int, vip *datatypes.
 				EditObject(vip)
 
 			if apiErr, ok := err.(sl.Error); ok {
-				// 500 could mean that the LB is busy with another transaction. Retry
+				// The LB is busy with another transaction. Retry
 				if apiErr.Exception == "SoftLayer_Exception_Network_Timeout" ||
 					strings.Contains(apiErr.Message, "There was a problem saving your configuration to the load balancer.") ||
 					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer.") {

--- a/softlayer/resource_softlayer_lb_local_service.go
+++ b/softlayer/resource_softlayer_lb_local_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/softlayer/softlayer-go/services"
 	"github.com/softlayer/softlayer-go/session"
 	"github.com/softlayer/softlayer-go/sl"
+	"strings"
 )
 
 func resourceSoftLayerLbLocalService() *schema.Resource {
@@ -250,8 +251,10 @@ func resourceSoftLayerLbLocalServiceDelete(d *schema.ResourceData, meta interfac
 
 			if apiErr, ok := err.(sl.Error); ok {
 				switch {
-				case apiErr.StatusCode == 500 && apiErr.Exception == "SoftLayer_Exception_Network_Timeout":
-					// 500/Network_Timeout could mean that the LB is busy with another transaction. Retry
+				case apiErr.Exception == "SoftLayer_Exception_Network_Timeout" ||
+					strings.Contains(apiErr.Message, "There was a problem saving your configuration to the load balancer.") ||
+					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer."):
+					// The LB is busy with another transaction. Retry
 					return false, "pending", nil
 				case apiErr.StatusCode == 404:
 					// 404 - service was deleted on the previous attempt
@@ -325,7 +328,9 @@ func updateLoadBalancerService(sess *session.Session, vipID int, vip *datatypes.
 
 			if apiErr, ok := err.(sl.Error); ok {
 				// 500 could mean that the LB is busy with another transaction. Retry
-				if apiErr.StatusCode == 500 {
+				if apiErr.Exception == "SoftLayer_Exception_Network_Timeout" ||
+					strings.Contains(apiErr.Message, "There was a problem saving your configuration to the load balancer.") ||
+					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer.") {
 					return false, "pending", nil
 				}
 

--- a/softlayer/resource_softlayer_lb_local_service.go
+++ b/softlayer/resource_softlayer_lb_local_service.go
@@ -253,7 +253,8 @@ func resourceSoftLayerLbLocalServiceDelete(d *schema.ResourceData, meta interfac
 				switch {
 				case apiErr.Exception == "SoftLayer_Exception_Network_Timeout" ||
 					strings.Contains(apiErr.Message, "There was a problem saving your configuration to the load balancer.") ||
-					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer."):
+					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer.") ||
+					strings.Contains(apiErr.Message, "The resource '480' is already in use."):
 					// The LB is busy with another transaction. Retry
 					return false, "pending", nil
 				case apiErr.StatusCode == 404:
@@ -330,7 +331,8 @@ func updateLoadBalancerService(sess *session.Session, vipID int, vip *datatypes.
 				// The LB is busy with another transaction. Retry
 				if apiErr.Exception == "SoftLayer_Exception_Network_Timeout" ||
 					strings.Contains(apiErr.Message, "There was a problem saving your configuration to the load balancer.") ||
-					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer.") {
+					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer.") ||
+					strings.Contains(apiErr.Message, "The resource '480' is already in use.") {
 					return false, "pending", nil
 				}
 

--- a/softlayer/resource_softlayer_lb_local_service_group.go
+++ b/softlayer/resource_softlayer_lb_local_service_group.go
@@ -199,7 +199,8 @@ func resourceSoftLayerLbLocalServiceGroupDelete(d *schema.ResourceData, meta int
 				switch {
 				case apiErr.Exception == "SoftLayer_Exception_Network_Timeout" ||
 					strings.Contains(apiErr.Message, "There was a problem saving your configuration to the load balancer.") ||
-					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer."):
+					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer.") ||
+					strings.Contains(apiErr.Message, "The resource '480' is already in use."):
 					// The LB is busy with another transaction. Retry
 					return false, "pending", nil
 				case apiErr.StatusCode == 404:

--- a/softlayer/resource_softlayer_lb_local_service_group_test.go
+++ b/softlayer/resource_softlayer_lb_local_service_group_test.go
@@ -14,13 +14,21 @@ func TestAccSoftLayerLbLocalServiceGroup_Basic(t *testing.T) {
 				Config: testAccCheckSoftLayerLbLocalServiceGroupConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"softlayer_lb_local_service_group.test_service_group", "port", "82"),
+						"softlayer_lb_local_service_group.test_service_group1", "port", "82"),
 					resource.TestCheckResourceAttr(
-						"softlayer_lb_local_service_group.test_service_group", "routing_method", "CONSISTENT_HASH_IP"),
+						"softlayer_lb_local_service_group.test_service_group1", "routing_method", "CONSISTENT_HASH_IP"),
 					resource.TestCheckResourceAttr(
-						"softlayer_lb_local_service_group.test_service_group", "routing_type", "HTTP"),
+						"softlayer_lb_local_service_group.test_service_group1", "routing_type", "HTTP"),
 					resource.TestCheckResourceAttr(
-						"softlayer_lb_local_service_group.test_service_group", "allocation", "100"),
+						"softlayer_lb_local_service_group.test_service_group1", "allocation", "50"),
+					resource.TestCheckResourceAttr(
+						"softlayer_lb_local_service_group.test_service_group2", "port", "83"),
+					resource.TestCheckResourceAttr(
+						"softlayer_lb_local_service_group.test_service_group2", "routing_method", "CONSISTENT_HASH_IP"),
+					resource.TestCheckResourceAttr(
+						"softlayer_lb_local_service_group.test_service_group2", "routing_type", "TCP"),
+					resource.TestCheckResourceAttr(
+						"softlayer_lb_local_service_group.test_service_group2", "allocation", "50"),
 				),
 			},
 		},
@@ -29,16 +37,24 @@ func TestAccSoftLayerLbLocalServiceGroup_Basic(t *testing.T) {
 
 const testAccCheckSoftLayerLbLocalServiceGroupConfig_basic = `
 resource "softlayer_lb_local" "testacc_foobar_lb" {
-    connections = 15000
-    datacenter    = "tok02"
+    connections = 250
+    datacenter    = "tor01"
     ha_enabled  = false
 }
 
-resource "softlayer_lb_local_service_group" "test_service_group" {
+resource "softlayer_lb_local_service_group" "test_service_group1" {
     port = 82
     routing_method = "CONSISTENT_HASH_IP"
     routing_type = "HTTP"
     load_balancer_id = "${softlayer_lb_local.testacc_foobar_lb.id}"
-    allocation = 100
+    allocation = 50
+}
+
+resource "softlayer_lb_local_service_group" "test_service_group2" {
+    port = 83
+    routing_method = "CONSISTENT_HASH_IP"
+    routing_type = "TCP"
+    load_balancer_id = "${softlayer_lb_local.testacc_foobar_lb.id}"
+    allocation = 50
 }
 `


### PR DESCRIPTION
SLAPI only accept one service group request per load balancer at the same time. When the plugin receives exceptions while requesting multiple service groups, it waits 10 seconds and retry. This fix resolves the issue #75 