### PR TITLE
Fix virtual guest transactipon

### DIFF
--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -987,7 +987,6 @@ func WaitForVirtualGuestAvailable(d *schema.ResourceData, meta interface{}) (int
 
 			// Check Primary IP address availability.
 			log.Println("Checking primary backend IP address.")
-
 			if result.PrimaryBackendIpAddress == nil {
 				return result, "provisioning", nil
 			}

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -963,10 +963,7 @@ func WaitForVirtualGuestAvailable(d *schema.ResourceData, meta interface{}) (int
 		return nil, fmt.Errorf("The instance ID %s must be numeric", d.Id())
 	}
 
-	ipAddress := "PrimaryIpAddress"
-	if d.Get("private_network_only").(bool) {
-		ipAddress = "PrimaryBackendIpAddress"
-	}
+	publicNetwork := !d.Get("private_network_only").(bool)
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"retry", "provisioning"},
@@ -982,14 +979,21 @@ func WaitForVirtualGuestAvailable(d *schema.ResourceData, meta interface{}) (int
 				return false, "retry", nil
 			}
 
+			// Check active transactions
 			log.Println("Checking active transactions.")
 			if result.ActiveTransaction != nil {
 				return result, "provisioning", nil
 			}
 
 			// Check Primary IP address availability.
-			log.Println("Checking Primary IP address.")
-			if sl.Get(result, ipAddress) == "" {
+			log.Println("Checking primary backend IP address.")
+
+			if result.PrimaryBackendIpAddress == nil {
+				return result, "provisioning", nil
+			}
+
+			log.Println("Checking primary IP address.")
+			if publicNetwork && result.PrimaryIpAddress == nil {
 				return result, "provisioning", nil
 			}
 


### PR DESCRIPTION
`sl.Get(result, ipAddress)` does not return "" when the result doesn't have ipAddress.
Removed `sl.Get` from `WaitForVirtualGuestAvailable` and directly checked the value of `result. PrimaryBackendIpAddress` and `result.PrimaryIpAddress` This fix is related to the issue #64