### PR TITLE
Checked the existence of billingItemID to prevent panic status.

### DIFF
--- a/softlayer/resource_softlayer_lb_local.go
+++ b/softlayer/resource_softlayer_lb_local.go
@@ -264,7 +264,7 @@ func resourceSoftLayerLbLocalDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if billingItem.Id == nil {
-		return fmt.Errorf("Error while looking up billing item associated with the storage: No billing item for ID:%d", vipID)
+		return fmt.Errorf("Error while looking up billing item associated with the load balancer: No billing item for ID:%d", vipID)
 	}
 
 	success, err := services.GetBillingItemService(sess).Id(*billingItem.Id).CancelService()

--- a/softlayer/resource_softlayer_lb_local.go
+++ b/softlayer/resource_softlayer_lb_local.go
@@ -263,6 +263,10 @@ func resourceSoftLayerLbLocalDelete(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error while looking up billing item associated with the load balancer: %s", err)
 	}
 
+	if billingItem.Id == nil {
+		return fmt.Errorf("Error while looking up billing item associated with the storage: No billing item for ID:%d", vipID)
+	}
+
 	success, err := services.GetBillingItemService(sess).Id(*billingItem.Id).CancelService()
 	if err != nil {
 		return err


### PR DESCRIPTION
If the load balancer doesn't have a billing item id, the delete function raises a panic error. To prevent panic status, I added a logic to check the `nil` status of `BillingItem.Id`.