### PR TITLE
Changed a property of ip_address_id to forceNew in lb_local_service.

### DIFF
--- a/softlayer/resource_softlayer_lb_local_service.go
+++ b/softlayer/resource_softlayer_lb_local_service.go
@@ -34,6 +34,7 @@ func resourceSoftLayerLbLocalService() *schema.Resource {
 			"ip_address_id": {
 				Type:     schema.TypeInt,
 				Required: true,
+				ForceNew: true,
 			},
 			"port": {
 				Type:     schema.TypeInt,
@@ -257,8 +258,8 @@ func resourceSoftLayerLbLocalServiceDelete(d *schema.ResourceData, meta interfac
 					strings.Contains(apiErr.Message, "The resource '480' is already in use."):
 					// The LB is busy with another transaction. Retry
 					return false, "pending", nil
-				case apiErr.StatusCode == 404:
-					// 404 - service was deleted on the previous attempt
+				case apiErr.StatusCode == 404 || // 404 - service was deleted on the previous attempt
+					strings.Contains(apiErr.Message, "Unable to find object with id"): // xmlrpc returns 200 instead of 404
 					return true, "complete", nil
 				default:
 					// Any other error is unexpected. Abort


### PR DESCRIPTION
Added `ForeceNew` property to `ip_address_id` parameter.
Checked `404` error code and error message as xmlrpc returns `200` code even if SL API fails to find an object.
This PR is related to #90 .