### PR TITLE
Global ipv6 support

### DIFF
--- a/docs/resources/softlayer_global_ip.md
+++ b/docs/resources/softlayer_global_ip.md
@@ -6,8 +6,16 @@ For additional details please refer to [API documentation](http://sldn.softlayer
 ## Example Usage
 
 ```hcl
+# Create a global IPv4 address
 resource "softlayer_global_ip" "test_global_ip " {
     routes_to = "119.81.82.163"
+}
+```
+
+```hcl
+# Create a global IPv6 address
+resource "softlayer_global_ip" "test_global_ip " {
+    routes_to = "2401:c900:1501:0032:0000:0000:0000:0003"
 }
 ```
 

--- a/softlayer/resource_softlayer_global_ip.go
+++ b/softlayer/resource_softlayer_global_ip.go
@@ -127,13 +127,14 @@ func resourceSoftLayerGlobalIpUpdate(d *schema.ResourceData, meta interface{}) e
 
 	routes_to := d.Get("routes_to").(string)
 	if strings.Contains(routes_to, ":") && len(routes_to) != 39 {
-		if colonCount := strings.Count(routes_to, ":"); colonCount != 7 {
-			routes_to = strings.Replace(routes_to, "::", "::"+strings.Repeat(":", 7-colonCount), 1)
-		}
-
 		parts := strings.Split(routes_to, ":")
 		for x, s := range parts {
-			parts[x] = fmt.Sprintf("%04s", s)
+			if s == "" {
+				zeroes := 9 - len(parts)
+				parts[x] = strings.Repeat("0000:", zeroes)[:(zeroes*4)+(zeroes-1)]
+			} else {
+				parts[x] = fmt.Sprintf("%04s", s)
+			}
 		}
 
 		routes_to = strings.Join(parts, ":")

--- a/softlayer/resource_softlayer_global_ip.go
+++ b/softlayer/resource_softlayer_global_ip.go
@@ -50,7 +50,7 @@ func resourceSoftLayerGlobalIp() *schema.Resource {
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					address := v.(string)
 					if net.ParseIP(address) == nil {
-						errors = append(errors, fmt.Errorf("Invalid IP"))
+						errors = append(errors, fmt.Errorf("Invalid IP format: %s", address))
 					}
 					return
 				},


### PR DESCRIPTION
- Validate func checks if IPv6 is given in full form(to work around http://stackoverflow.com/questions/41250975/softlayer-api-global-ip-routing-not-working-with-ipv6)
- Price switching based on whether IPv4/IPv6 is ordered
- Removed comment mentioning support for only IPv4
- Doc update
- Check for validity of IPv4/IPv6
- Uncompress IPv6 if necessary