### PR TITLE
Filter static ip only for secondary_ip_addresses parameter

### DIFF
--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -272,6 +272,9 @@ func resourceSoftLayerVirtualGuest() *schema.Resource {
 				ForceNew: true,
 				DiffSuppressFunc: func(k, o, n string, d *schema.ResourceData) bool {
 					// secondary_ip_count is only used when a virtual_guest resource is created.
+					if d.State() == nil {
+						return false
+					}
 					return true
 				},
 			},


### PR DESCRIPTION
GetAccountService::GetPublicSubnets returns both static IP addresses and global IP addresses. ObjectFilter has been added to added to return static IP addresses only. This PR resolves the issue #106 . The detailed updates are as follows:

- DiffSuppressFunc has been added to `secondary_ip_count` parameter to allow the update in creation time only.
- Updated the objectFilter query to get static IP addresses only. 