### PR TITLE
Check if n has the appropriate IPv6 format in global IP.

### DIFF
--- a/softlayer/resource_softlayer_global_ip.go
+++ b/softlayer/resource_softlayer_global_ip.go
@@ -55,7 +55,10 @@ func resourceSoftLayerGlobalIp() *schema.Resource {
 					return
 				},
 				DiffSuppressFunc: func(k, o, n string, d *schema.ResourceData) bool {
-					return net.ParseIP(o).String() == net.ParseIP(n).String()
+					newRoutesTo := net.ParseIP(n)
+					// Return true when n has the appropriate IPv6 format and
+					// the compressed value of n equals the compressed value of o.
+					return newRoutesTo != nil && (newRoutesTo.String() == net.ParseIP(o).String())
 				},
 			},
 		},


### PR DESCRIPTION
When an interpolation syntax is used for _routes_to_, _net.ParseIP().String()_ function returns _nil_ and _DiffSuppressFunc()_ function returns _true_ in _resourceSoftLayerGlobalIpCreate()_ function.
In global IP acceptance test, _routes_to = "${softlayer_virtual_guest.vm2.ipv4_address}"_ and `terraform plan` ignores _routes_to_ as DiffSuppressFunc() returns `true`.
This fix checks if _routes_to_ value has the appropriate IPv6 format. 
It will resolve the issue #113 