### PR TITLE
IPv6 support for firewall rules

### DIFF
--- a/docs/resources/softlayer_fw_hardware_dedicated_rules.md
+++ b/docs/resources/softlayer_fw_hardware_dedicated_rules.md
@@ -8,9 +8,9 @@ rules. For additional details please refer to
 
 _Please Note_: Target VLAN should have at least one subnet for rule 
 configuration. To express _ANY IP addresses_ in external side, configure 
-`src_ip_address` as `0.0.0.0` and `src_ip_cidr` as `0`. To express _API 
+`src_ip_address` as `0.0.0.0`(`0::` for IPv6) and `src_ip_cidr` as `0`. To express _API 
 IP addresses_ in internal side, configure `dst_ip_address` as `any` and 
-`src_ip_cidr` as `32`. Once `softlayer_fw_hardware_dedicated_rules` resource 
+`src_ip_cidr` as `32`(`128` for IPv6). Once `softlayer_fw_hardware_dedicated_rules` resource 
 is created, it cannot be deleted. SoftLayer doesnot allow entire rule deleting. 
 Firewalls should have at least one rule. If terraform destroys 
 `softlayer_fw_hardware_dedicated_rules` resources, _permit from any to any
@@ -24,6 +24,8 @@ resource "softlayer_fw_hardware_dedicated" "demofw" {
 
 resource "softlayer_fw_hardware_dedicated_rules" "rules" {
  firewall_id = "${softlayer_fw_hardware_dedicated.demofw.id}"
+
+ # Rules for IPv4
  rules = {
       "action" = "permit"
       "src_ip_address"= "10.1.1.0"
@@ -46,6 +48,19 @@ resource "softlayer_fw_hardware_dedicated_rules" "rules" {
        "notes"= "Permit from 10.1.1.0"
        "protocol"= "udp"
   }
+
+ # Rules for IPv6
+ rules = {
+      "action" = "permit"
+      "src_ip_address"= "2401:c900:1501:0032:0000:0000:0000:0003"
+      "src_ip_cidr"= 128
+      "dst_ip_address"= "any"
+      "dst_ip_cidr"= 128
+      "dst_port_range_start"= 80
+      "dst_port_range_end"= 80
+      "notes"= "Permit for IPv6"
+      "protocol"= "tcp"
+ }
 }
 ```
 

--- a/softlayer/resource_softlayer_fw_hardware_dedicated_rules.go
+++ b/softlayer/resource_softlayer_fw_hardware_dedicated_rules.go
@@ -227,7 +227,20 @@ func appendAnyOpenRule(rules []datatypes.Network_Firewall_Update_Request_Rule, p
 		Protocol:                  sl.String(protocol),
 		Notes:                     sl.String("terraform-default-anyopen-" + protocol),
 	}
-	return append(rules, ruleAnyOpen)
+
+	ruleAnyOpenIpv6 := datatypes.Network_Firewall_Update_Request_Rule{
+		OrderValue:                sl.Int(len(rules) + 1),
+		Action:                    sl.String("permit"),
+		SourceIpAddress:           sl.String("any"),
+		DestinationIpAddress:      sl.String("any"),
+		DestinationPortRangeStart: sl.Int(1),
+		DestinationPortRangeEnd:   sl.Int(65535),
+		Protocol:                  sl.String(protocol),
+		Notes:                     sl.String("terraform-default-anyopen-" + protocol + "-ipv6"),
+		Version:                   sl.Int(6),
+	}
+
+	return append(rules, ruleAnyOpen, ruleAnyOpenIpv6)
 }
 
 func resourceSoftLayerFwHardwareDedicatedRulesUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/softlayer/resource_softlayer_fw_hardware_dedicated_rules_test.go
+++ b/softlayer/resource_softlayer_fw_hardware_dedicated_rules_test.go
@@ -42,6 +42,22 @@ func TestAccSoftLayerFwHardwareDedicatedRules_Basic(t *testing.T) {
 						"softlayer_fw_hardware_dedicated_rules.rules", "rules.1.notes", "Allow SSH"),
 					resource.TestCheckResourceAttr(
 						"softlayer_fw_hardware_dedicated_rules.rules", "rules.1.protocol", "tcp"),
+
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.2.action", "permit"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.2.src_ip_address",
+						"0000:0000:0000:0000:0000:0000:0000:0000"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.2.dst_ip_address", "any"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.2.dst_port_range_start", "22"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.2.dst_port_range_end", "22"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.2.notes", "Allow SSH"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.2.protocol", "tcp"),
 				),
 			},
 			resource.TestStep{
@@ -59,6 +75,19 @@ func TestAccSoftLayerFwHardwareDedicatedRules_Basic(t *testing.T) {
 						"softlayer_fw_hardware_dedicated_rules.rules", "rules.0.notes", "Permit from 10.1.1.0"),
 					resource.TestCheckResourceAttr(
 						"softlayer_fw_hardware_dedicated_rules.rules", "rules.0.protocol", "udp"),
+
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.1.action", "deny"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.1.src_ip_address", "2401:c900:1501:0032:0000:0000:0000:0000"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.1.dst_port_range_start", "80"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.1.dst_port_range_end", "80"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.1.notes", "Deny for IPv6"),
+					resource.TestCheckResourceAttr(
+						"softlayer_fw_hardware_dedicated_rules.rules", "rules.1.protocol", "udp"),
 				),
 			},
 		},
@@ -109,6 +138,17 @@ resource "softlayer_fw_hardware_dedicated_rules" "rules" {
       "notes"= "Allow SSH"
       "protocol"= "tcp"
  }
+ rules = {
+      "action" = "permit"
+      "src_ip_address"= "0::"
+      "src_ip_cidr"= 0
+      "dst_ip_address"= "any"
+      "dst_ip_cidr"= 128
+      "dst_port_range_start"= 22
+      "dst_port_range_end"= 22
+      "notes"= "Allow SSH"
+      "protocol"= "tcp"
+ }
 }
 
 `
@@ -146,6 +186,16 @@ resource "softlayer_fw_hardware_dedicated_rules" "rules" {
       "notes"= "Permit from 10.1.1.0"
       "protocol"= "udp"
  }
+ rules = {
+      "action" = "deny"
+      "src_ip_address"= "2401:c900:1501:0032:0000:0000:0000:0000"
+      "src_ip_cidr"= 64
+      "dst_ip_address"= "any"
+      "dst_ip_cidr"= 128
+      "dst_port_range_start"= 80
+      "dst_port_range_end"= 80
+      "notes"= "Deny for IPv6"
+      "protocol"= "udp"
+ }
 }
-
 `


### PR DESCRIPTION
- Enables creation of IPv6 rules
- IPv6 expansion logic is not needed since API accepts compressed and uncompressed format
