### PR TITLE
Fix scale group

### DIFF
--- a/softlayer/resource_softlayer_lb_local_service_group.go
+++ b/softlayer/resource_softlayer_lb_local_service_group.go
@@ -200,6 +200,7 @@ func resourceSoftLayerLbLocalServiceGroupDelete(d *schema.ResourceData, meta int
 				case apiErr.Exception == "SoftLayer_Exception_Network_Timeout" ||
 					strings.Contains(apiErr.Message, "There was a problem saving your configuration to the load balancer.") ||
 					strings.Contains(apiErr.Message, "The selected group could not be removed from the load balancer.") ||
+					strings.Contains(apiErr.Message, "An error has occurred while processing your request.") ||
 					strings.Contains(apiErr.Message, "The resource '480' is already in use."):
 					// The LB is busy with another transaction. Retry
 					return false, "pending", nil

--- a/softlayer/resource_softlayer_scale_group_test.go
+++ b/softlayer/resource_softlayer_scale_group_test.go
@@ -68,7 +68,6 @@ func TestAccSoftLayerScaleGroup_Basic(t *testing.T) {
 						"softlayer_scale_group.sample-http-cluster", "virtual_guest_member_template.0.post_install_script_uri", ""),
 					resource.TestCheckResourceAttr(
 						"softlayer_scale_group.sample-http-cluster", "virtual_guest_member_template.0.user_metadata", "#!/bin/bash"),
-					testAccCheckSoftLayerScaleGroupContainsNetworkVlan(&scalegroup, 1928, "bcr02a.sng01"),
 				),
 			},
 
@@ -192,7 +191,7 @@ func testAccCheckSoftLayerScaleGroupExists(n string, scalegroup *datatypes.Scale
 
 const testAccCheckSoftLayerScaleGroupConfig_basic = `
 resource "softlayer_lb_local" "local_lb_01" {
-    connections = 15000
+    connections = 250
     datacenter = "sng01"
     ha_enabled = false
 }
@@ -235,7 +234,7 @@ resource "softlayer_scale_group" "sample-http-cluster" {
 
 const testAccCheckSoftLayerScaleGroupConfig_updated = `
 resource "softlayer_lb_local" "local_lb_01" {
-    connections = 15000
+    connections = 250
     datacenter = "sng01"
     ha_enabled = false
 }


### PR DESCRIPTION
Service fixes are applied for the scale group and local load balancer as follows:
- Added an exception handling string for the service group of the local load balancer.
- Deleted `wait_time_minutes` parameter from virtual_guest_template in scale_group. It resolves the issue #109 
- Send ID of the scale load balancer when scale group is updated. 
- Check member VM's public IP and private IP status to check the provisioning status as sometimes VM doesn't provide an active transaction information.
- Increased timeout from 10 mins to 120 mins for scale group creation. 
- Change load balancer specification from 15000 connections to 250 connections in scale_group_test.