### PR TITLE
Block storage concurrency issue

### DIFF
--- a/softlayer/resource_softlayer_file_storage.go
+++ b/softlayer/resource_softlayer_file_storage.go
@@ -723,16 +723,24 @@ func updateAllowedIpAddresses(d *schema.ResourceData, sess *session.Session, sto
 			if len(ipObject) != 1 {
 				return fmt.Errorf("Number of IP address is %d", len(ipObject))
 			}
-			_, err = services.GetNetworkStorageService(sess).
-				Id(id).
-				AllowAccessFromHostList([]datatypes.Container_Network_Storage_Host{
-					{
-						Id:         ipObject[0].Id,
-						ObjectType: sl.String("SoftLayer_Network_Subnet_IpAddress"),
-					},
-				})
-			if err != nil {
-				return err
+
+			for {
+				_, err = services.GetNetworkStorageService(sess).
+					Id(id).
+					AllowAccessFromHostList([]datatypes.Container_Network_Storage_Host{
+						{
+							Id:         ipObject[0].Id,
+							ObjectType: sl.String("SoftLayer_Network_Subnet_IpAddress"),
+						},
+					})
+				if err != nil {
+					if strings.Contains(err.Error(), "SoftLayer_Exception_Network_Storage_Group_MassAccessControlModification") {
+						time.Sleep(5 * time.Second)
+						continue
+					}
+					return err
+				}
+				break
 			}
 		}
 	}
@@ -747,16 +755,23 @@ func updateAllowedIpAddresses(d *schema.ResourceData, sess *session.Session, sto
 			}
 		}
 		if isDeletedId {
-			_, err := services.GetNetworkStorageService(sess).
-				Id(id).
-				RemoveAccessFromHostList([]datatypes.Container_Network_Storage_Host{
-					{
-						Id:         oldAllowedIpAddresses.Id,
-						ObjectType: sl.String("SoftLayer_Network_Subnet_IpAddress"),
-					},
-				})
-			if err != nil {
-				return err
+			for {
+				_, err := services.GetNetworkStorageService(sess).
+					Id(id).
+					RemoveAccessFromHostList([]datatypes.Container_Network_Storage_Host{
+						{
+							Id:         oldAllowedIpAddresses.Id,
+							ObjectType: sl.String("SoftLayer_Network_Subnet_IpAddress"),
+						},
+					})
+				if err != nil {
+					if strings.Contains(err.Error(), "SoftLayer_Exception_Network_Storage_Group_MassAccessControlModification") {
+						time.Sleep(5 * time.Second)
+						continue
+					}
+					return err
+				}
+				break
 			}
 		}
 	}
@@ -853,16 +868,23 @@ func updateAllowedVirtualGuestIds(d *schema.ResourceData, sess *session.Session,
 			}
 		}
 		if isNewId {
-			_, err := services.GetNetworkStorageService(sess).
-				Id(id).
-				AllowAccessFromHostList([]datatypes.Container_Network_Storage_Host{
-					{
-						Id:         sl.Int(newId.(int)),
-						ObjectType: sl.String("SoftLayer_Virtual_Guest"),
-					},
-				})
-			if err != nil {
-				return err
+			for {
+				_, err := services.GetNetworkStorageService(sess).
+					Id(id).
+					AllowAccessFromHostList([]datatypes.Container_Network_Storage_Host{
+						{
+							Id:         sl.Int(newId.(int)),
+							ObjectType: sl.String("SoftLayer_Virtual_Guest"),
+						},
+					})
+				if err != nil {
+					if strings.Contains(err.Error(), "SoftLayer_Exception_Network_Storage_Group_MassAccessControlModification") {
+						time.Sleep(5 * time.Second)
+						continue
+					}
+					return err
+				}
+				break
 			}
 		}
 	}
@@ -877,16 +899,23 @@ func updateAllowedVirtualGuestIds(d *schema.ResourceData, sess *session.Session,
 			}
 		}
 		if isDeletedId {
-			_, err := services.GetNetworkStorageService(sess).
-				Id(id).
-				RemoveAccessFromHostList([]datatypes.Container_Network_Storage_Host{
-					{
-						Id:         sl.Int(*oldAllowedVirtualGuest.Id),
-						ObjectType: sl.String("SoftLayer_Virtual_Guest"),
-					},
-				})
-			if err != nil {
-				return err
+			for {
+				_, err := services.GetNetworkStorageService(sess).
+					Id(id).
+					RemoveAccessFromHostList([]datatypes.Container_Network_Storage_Host{
+						{
+							Id:         sl.Int(*oldAllowedVirtualGuest.Id),
+							ObjectType: sl.String("SoftLayer_Virtual_Guest"),
+						},
+					})
+				if err != nil {
+					if strings.Contains(err.Error(), "SoftLayer_Exception_Network_Storage_Group_MassAccessControlModification") {
+						time.Sleep(5 * time.Second)
+						continue
+					}
+					return err
+				}
+				break
 			}
 		}
 	}

--- a/softlayer/resource_softlayer_file_storage.go
+++ b/softlayer/resource_softlayer_file_storage.go
@@ -30,6 +30,7 @@ const (
 	performanceType = "Performance"
 	fileStorage     = "FILE_STORAGE"
 	blockStorage    = "BLOCK_STORAGE"
+	retryTime       = 5
 )
 
 var (
@@ -735,7 +736,7 @@ func updateAllowedIpAddresses(d *schema.ResourceData, sess *session.Session, sto
 					})
 				if err != nil {
 					if strings.Contains(err.Error(), "SoftLayer_Exception_Network_Storage_Group_MassAccessControlModification") {
-						time.Sleep(5 * time.Second)
+						time.Sleep(retryTime * time.Second)
 						continue
 					}
 					return err
@@ -766,7 +767,7 @@ func updateAllowedIpAddresses(d *schema.ResourceData, sess *session.Session, sto
 					})
 				if err != nil {
 					if strings.Contains(err.Error(), "SoftLayer_Exception_Network_Storage_Group_MassAccessControlModification") {
-						time.Sleep(5 * time.Second)
+						time.Sleep(retryTime * time.Second)
 						continue
 					}
 					return err
@@ -879,7 +880,7 @@ func updateAllowedVirtualGuestIds(d *schema.ResourceData, sess *session.Session,
 					})
 				if err != nil {
 					if strings.Contains(err.Error(), "SoftLayer_Exception_Network_Storage_Group_MassAccessControlModification") {
-						time.Sleep(5 * time.Second)
+						time.Sleep(retryTime * time.Second)
 						continue
 					}
 					return err
@@ -910,7 +911,7 @@ func updateAllowedVirtualGuestIds(d *schema.ResourceData, sess *session.Session,
 					})
 				if err != nil {
 					if strings.Contains(err.Error(), "SoftLayer_Exception_Network_Storage_Group_MassAccessControlModification") {
-						time.Sleep(5 * time.Second)
+						time.Sleep(retryTime * time.Second)
 						continue
 					}
 					return err


### PR DESCRIPTION
- If `SoftLayer_Exception_Network_Storage_Group_MassAccessControlModification` is encountered, the code waits and retries.
- Block storage uses functions from file storage resource, hence change will only be required in `resource_softlayer_file_storage.go`.