### PR TITLE
Removing all tags from a Baremetal or Virtual Guest is done by using an empty string

### DIFF
--- a/softlayer/resource_softlayer_bare_metal.go
+++ b/softlayer/resource_softlayer_bare_metal.go
@@ -526,11 +526,9 @@ func setHardwareTags(id int, d *schema.ResourceData, meta interface{}) error {
 	service := services.GetHardwareService(meta.(ProviderConfig).SoftLayerSession())
 
 	tags := getTags(d)
-	if tags != "" {
-		_, err := service.Id(id).SetTags(sl.String(tags))
-		if err != nil {
-			return fmt.Errorf("Could not set tags on bare metal server %d", id)
-		}
+	_, err := service.Id(id).SetTags(sl.String(tags))
+	if err != nil {
+		return fmt.Errorf("Could not set tags on bare metal server %d", id)
 	}
 
 	return nil

--- a/softlayer/resource_softlayer_virtual_guest.go
+++ b/softlayer/resource_softlayer_virtual_guest.go
@@ -1114,11 +1114,9 @@ func setGuestTags(id int, d *schema.ResourceData, meta interface{}) error {
 	service := services.GetVirtualGuestService(meta.(ProviderConfig).SoftLayerSession())
 
 	tags := getTags(d)
-	if tags != "" {
-		_, err := service.Id(id).SetTags(sl.String(tags))
-		if err != nil {
-			return fmt.Errorf("Could not set tags on virtual guest %d", id)
-		}
+	_, err := service.Id(id).SetTags(sl.String(tags))
+	if err != nil {
+		return fmt.Errorf("Could not set tags on virtual guest %d", id)
 	}
 
 	return nil


### PR DESCRIPTION
This  PR should address https://github.com/softlayer/terraform-provider-softlayer/issues/139

Based on the documentation that can be found here: [https://github.com/softlayer/softlayer-go/blob/master/services/tag.go#L114](https://github.com/softlayer/softlayer-go/blob/58a39b003905ea63e4ad9bbfc48b3c9abfcea0bb/services/tag.go#L114)

Didn't had the chance to test it yet.