### PR TITLE
Support notes on file storage and expose network mount address

### DIFF
--- a/docs/resources/softlayer_file_storage.md
+++ b/docs/resources/softlayer_file_storage.md
@@ -80,3 +80,4 @@ The following attributes are exported:
 * `id` - id of the storage.
 * `hostname` - The fully qualified domain name of the storage. 
 * `volumename` - The name of the storage volume.
+* `mountpoint` - The network mount address of the storage.

--- a/docs/resources/softlayer_file_storage.md
+++ b/docs/resources/softlayer_file_storage.md
@@ -68,6 +68,9 @@ The following arguments are supported:
 * `allowed_ip_addresses` | *array of string*
     * Specifies allowed IP addresses. IP addresses should be in the same data center.
     * **Optional**    
+* `notes` | *string*
+    * Specifies a note to associate with the file storage.
+    * **Optional**    
     
 
 ## Attributes Reference

--- a/softlayer/resource_softlayer_file_storage.go
+++ b/softlayer/resource_softlayer_file_storage.go
@@ -171,6 +171,11 @@ func resourceSoftLayerFileStorage() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"mountpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -315,6 +320,12 @@ func resourceSoftLayerFileStorageRead(d *schema.ResourceData, meta interface{}) 
 	if storage.Notes != nil {
 		d.Set("notes", *storage.Notes)
 	}
+
+	mountpoint, err := services.GetNetworkStorageService(sess).Id(storageId).GetFileNetworkMountAddress()
+	if err != nil {
+		return fmt.Errorf("Error retrieving storage information: %s", err)
+	}
+	d.Set("mountpoint", mountpoint)
 
 	return nil
 }

--- a/softlayer/resource_softlayer_file_storage_test.go
+++ b/softlayer/resource_softlayer_file_storage_test.go
@@ -32,6 +32,7 @@ func TestAccSoftLayerFileStorage_Basic(t *testing.T) {
 					testAccCheckSoftLayerResources("softlayer_file_storage.fs_endurance", "datacenter",
 						"softlayer_virtual_guest.storagevm1", "datacenter"),
 					resource.TestCheckResourceAttr("softlayer_file_storage.fs_endurance", "notes", "endurance notes"),
+					resource.TestCheckResourceAttrSet("softlayer_file_storage.fs_endurance", "mountpoint"),
 					// Performance Storage
 					testAccCheckSoftLayerFileStorageExists("softlayer_file_storage.fs_performance"),
 					resource.TestCheckResourceAttr(
@@ -43,6 +44,7 @@ func TestAccSoftLayerFileStorage_Basic(t *testing.T) {
 					testAccCheckSoftLayerResources("softlayer_file_storage.fs_performance", "datacenter",
 						"softlayer_virtual_guest.storagevm1", "datacenter"),
 					resource.TestCheckResourceAttr("softlayer_file_storage.fs_performance", "notes", "performance notes"),
+					resource.TestCheckResourceAttrSet("softlayer_file_storage.fs_performance", "mountpoint"),
 				),
 			},
 

--- a/softlayer/resource_softlayer_file_storage_test.go
+++ b/softlayer/resource_softlayer_file_storage_test.go
@@ -31,6 +31,7 @@ func TestAccSoftLayerFileStorage_Basic(t *testing.T) {
 						"softlayer_file_storage.fs_endurance", "snapshot_capacity", "10"),
 					testAccCheckSoftLayerResources("softlayer_file_storage.fs_endurance", "datacenter",
 						"softlayer_virtual_guest.storagevm1", "datacenter"),
+					resource.TestCheckResourceAttr("softlayer_file_storage.fs_endurance", "notes", "endurance notes"),
 					// Performance Storage
 					testAccCheckSoftLayerFileStorageExists("softlayer_file_storage.fs_performance"),
 					resource.TestCheckResourceAttr(
@@ -41,6 +42,7 @@ func TestAccSoftLayerFileStorage_Basic(t *testing.T) {
 						"softlayer_file_storage.fs_performance", "iops", "100"),
 					testAccCheckSoftLayerResources("softlayer_file_storage.fs_performance", "datacenter",
 						"softlayer_virtual_guest.storagevm1", "datacenter"),
+					resource.TestCheckResourceAttr("softlayer_file_storage.fs_performance", "notes", "performance notes"),
 				),
 			},
 
@@ -51,10 +53,12 @@ func TestAccSoftLayerFileStorage_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("softlayer_file_storage.fs_endurance", "allowed_virtual_guest_ids.#", "1"),
 					resource.TestCheckResourceAttr("softlayer_file_storage.fs_endurance", "allowed_subnets.#", "1"),
 					resource.TestCheckResourceAttr("softlayer_file_storage.fs_endurance", "allowed_ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr("softlayer_file_storage.fs_endurance", "notes", "updated endurance notes"),
 					// Performance Storage
 					resource.TestCheckResourceAttr("softlayer_file_storage.fs_performance", "allowed_virtual_guest_ids.#", "1"),
 					resource.TestCheckResourceAttr("softlayer_file_storage.fs_performance", "allowed_subnets.#", "1"),
 					resource.TestCheckResourceAttr("softlayer_file_storage.fs_performance", "allowed_ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr("softlayer_file_storage.fs_performance", "notes", ""),
 				),
 			},
 		},
@@ -111,6 +115,7 @@ resource "softlayer_file_storage" "fs_endurance" {
         capacity = 20
         iops = 0.25
         snapshot_capacity = 10
+        notes = "endurance notes"
 }
 
 resource "softlayer_file_storage" "fs_performance" {
@@ -118,6 +123,7 @@ resource "softlayer_file_storage" "fs_performance" {
         datacenter = "${softlayer_virtual_guest.storagevm1.datacenter}"
         capacity = 20
         iops = 100
+        notes = "performance notes"
 }
 `
 const testAccCheckSoftLayerFileStorageConfig_update = `
@@ -144,6 +150,7 @@ resource "softlayer_file_storage" "fs_endurance" {
         allowed_subnets = [ "${softlayer_virtual_guest.storagevm1.private_subnet}" ]
         allowed_ip_addresses = [ "${softlayer_virtual_guest.storagevm1.ipv4_address_private}" ]
         snapshot_capacity = 10
+        notes = "updated endurance notes"
 }
 
 resource "softlayer_file_storage" "fs_performance" {


### PR DESCRIPTION
Console calls it a "mount point" and the API calls it a "network mount address". Either name could work so happy to change.
