### PR TITLE
Checked a user with CANCEL_PENDING status in userExists function.

### DIFF
--- a/softlayer/resource_softlayer_user.go
+++ b/softlayer/resource_softlayer_user.go
@@ -474,6 +474,13 @@ func resourceSoftLayerUserExists(d *schema.ResourceData, meta interface{}) (bool
 
 	result, err := service.Id(id).GetObject()
 
+	// When a user is deleted, it has remained with "CANCEL_PENDING" status in specific time period.
+	// The user with this status should be considered as a non-exist user.
+	if result.UserStatus != nil && result.UserStatus.KeyName != nil &&
+		*result.UserStatus.KeyName == "CANCEL_PENDING" {
+		return false, nil
+	}
+
 	return result.Id != nil && *result.Id == id && err == nil, nil
 }
 

--- a/softlayer/resource_softlayer_user.go
+++ b/softlayer/resource_softlayer_user.go
@@ -491,7 +491,7 @@ func resourceSoftLayerUserExists(d *schema.ResourceData, meta interface{}) (bool
 		}
 		return false, fmt.Errorf("Error retrieving user information: %s", err)
 	}
-	return true, nil
+	return result.Id != nil && *result.Id == id, nil
 }
 
 func getTimezoneIDByName(sess *session.Session, shortName string) (int, error) {


### PR DESCRIPTION
When a user is deleted, it has remained internally with "CANCEL_PENDING" status in a specific period. Although a user ID still exists, user information is already removed and cannot be recovered. The user with this status should be considered as a non-exist user. This fix will resolve the issue #154.