### PR TITLE
 interpolate primary vlan correctly

### DIFF
--- a/softlayer/resource_softlayer_vlan.go
+++ b/softlayer/resource_softlayer_vlan.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
-	"regexp"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -210,12 +210,12 @@ func resourceSoftLayerVlanRead(d *schema.ResourceData, meta interface{}) error {
 		if validPrimaryType.MatchString(*elem.SubnetType) {
 			primarySubnet["subnet"] = fmt.Sprintf("%s/%s", *elem.NetworkIdentifier, strconv.Itoa(*elem.Cidr))
 			primarySubnet["subnet_type"] = *elem.SubnetType
-			primarySubnet["subnet_size"] = 1<<(uint)(32-*elem.Cidr)
+			primarySubnet["subnet_size"] = 1 << (uint)(32-*elem.Cidr)
 			primarySubnets = append(primarySubnets, primarySubnet)
-	  }
+		}
 		subnet["subnet"] = fmt.Sprintf("%s/%s", *elem.NetworkIdentifier, strconv.Itoa(*elem.Cidr))
 		subnet["subnet_type"] = *elem.SubnetType
-		subnet["subnet_size"] = 1<<(uint)(32-*elem.Cidr)
+		subnet["subnet_size"] = 1 << (uint)(32-*elem.Cidr)
 		subnets = append(subnets, subnet)
 	}
 	d.Set("subnets", subnets)


### PR DESCRIPTION
Fix for #164 

changes made to the softlayer_vlan resource
* identify primary subnets
* set subnet_size according to first primary subnet
* create "softlayer_vlan.subnets.<subnet_id>.subnet_size" property

